### PR TITLE
Web Balance Report

### DIFF
--- a/hledger-web/Hledger/Web/App.hs
+++ b/hledger-web/Hledger/Web/App.hs
@@ -144,6 +144,8 @@ instance Yesod App where
           }
         rspec' = rspec{_rsQuery=q,_rsReportOpts=ropts'}
 
+    maybePeriod <- lookupGetParam "period"
+
     hideEmptyAccts <- if empty_ ropts
                          then return True
                          else (== Just "1") . lookup "hideemptyaccts" . reqCookies <$> getRequest

--- a/hledger-web/Hledger/Web/Application.hs
+++ b/hledger-web/Hledger/Web/Application.hs
@@ -28,6 +28,7 @@ import Hledger.Web.Handler.EditR
 import Hledger.Web.Handler.UploadR
 import Hledger.Web.Handler.JournalR
 import Hledger.Web.Handler.RegisterR
+import Hledger.Web.Handler.BalanceR
 import Hledger.Web.Import
 import Hledger.Web.WebOptions (ServerMode(..), WebOpts(server_mode_), corsPolicy)
 

--- a/hledger-web/Hledger/Web/Handler/BalanceR.hs
+++ b/hledger-web/Hledger/Web/Handler/BalanceR.hs
@@ -1,0 +1,62 @@
+-- | /balance handlers.
+
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hledger.Web.Handler.BalanceR where
+
+import Hledger
+import Hledger.Cli.CliOptions
+import Hledger.Write.Html.Blaze (styledTableHtml)
+import Hledger.Web.Import
+import Hledger.Web.WebOptions
+import qualified Hledger.Cli.Commands.Balance as Balance
+import qualified Hledger.Query as Query
+
+import Text.Megaparsec.Error (errorBundlePretty)
+import qualified Text.Blaze.Html4.Strict as Blaze
+import qualified Data.Text as Text
+import qualified Yesod
+
+
+-- | The balance or multi-period balance view, with sidebar.
+getBalanceR :: Handler Html
+getBalanceR = do
+  checkServerSideUiEnabled
+  VD{j, q, qparam, opts, today} <- getViewData
+  require ViewPermission
+  let title :: Text
+      title = "Balance Report" <> if q /= Any then ", filtered" else ""
+      rspecOrig = reportspec_ $ cliopts_ opts
+      ropts =
+        (_rsReportOpts rspecOrig) {
+          balance_base_url_ = Just "",
+          querystring_ = Query.words'' queryprefixes qparam
+        }
+      rspec =
+        rspecOrig {
+          _rsQuery = filterQuery (not . queryIsDepth) q,
+          _rsReportOpts = ropts
+        }
+
+  defaultLayout $ do
+    mperiod <- lookupGetParam "period"
+    case mperiod of
+      Nothing -> do
+        setTitle "balance - hledger-web"
+        Yesod.toWidget .
+          (Blaze.h2 (Blaze.toHtml title) >>) .
+          styledTableHtml . map (map (fmap Blaze.toHtml)) .
+          Balance.balanceReportAsSpreadsheet ropts $
+            balanceReport rspec j
+      Just perStr -> do
+        setTitle "multibalance - hledger-web"
+        case parsePeriodExpr today perStr of
+          Left msg -> Yesod.toWidget $ Text.pack $ errorBundlePretty msg
+          Right (per_,_) ->
+            Yesod.toWidget .
+              (Blaze.h2 (Blaze.toHtml title) >>) .
+              styledTableHtml . map (map (fmap Blaze.toHtml)) .
+              snd . Balance.multiBalanceReportAsSpreadsheet ropts $
+                let rspec' = rspec{_rsReportOpts = ropts{interval_ = per_}} in
+                multiBalanceReport rspec' j

--- a/hledger-web/Hledger/Web/Handler/JournalR.hs
+++ b/hledger-web/Hledger/Web/Handler/JournalR.hs
@@ -16,6 +16,8 @@ import Hledger.Web.Widget.Common
             (accountQuery, mixedAmountAsHtml,
              transactionFragment, replaceInacct)
 
+import qualified Data.Text as Text
+
 -- | The formatted journal view, with sidebar.
 getJournalR :: Handler Html
 getJournalR = do
@@ -27,6 +29,9 @@ getJournalR = do
         Just (a, inclsubs) -> "Transactions in " <> a <> if inclsubs then "" else " (excluding subaccounts)"
       title' = title <> if q /= Any then ", filtered" else ""
       acctlink a = (RegisterR, [("q", replaceInacct qparam $ accountQuery a)])
+      qparamOpt = if Text.null qparam then [] else [("q",qparam)]
+      ballink = (BalanceR, qparamOpt)
+      multiballink per_ = (BalanceR, ("period",per_) : qparamOpt)
       rspec = (reportspec_ $ cliopts_ opts){_rsQuery = filterQuery (not . queryIsDepth) q}
       items = reverse $
         styleAmounts (journalCommodityStylesWith HardRounding j) $

--- a/hledger-web/config/routes
+++ b/hledger-web/config/routes
@@ -7,6 +7,7 @@
 /                RootR           GET
 /journal         JournalR        GET
 /register        RegisterR       GET
+/balance         BalanceR        GET
 /add             AddR            GET POST PUT
 
 /manage             ManageR         GET

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -144,6 +144,7 @@ library
   other-modules:
       Hledger.Web.App
       Hledger.Web.Handler.AddR
+      Hledger.Web.Handler.BalanceR
       Hledger.Web.Handler.EditR
       Hledger.Web.Handler.JournalR
       Hledger.Web.Handler.MiscR
@@ -187,6 +188,7 @@ library
     , http-client
     , http-conduit
     , http-types
+    , lucid
     , megaparsec >=7.0.0 && <9.8
     , mtl >=2.2.1
     , network

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -131,6 +131,7 @@ library:
   - http-conduit
   - http-client
   - http-types
+  - lucid
   - megaparsec >=7.0.0 && <9.8
   - mtl >=2.2.1
   - network

--- a/hledger-web/templates/default-layout.hamlet
+++ b/hledger-web/templates/default-layout.hamlet
@@ -19,6 +19,8 @@ $if elem ViewPermission perms
     <form#searchform.input-group method=GET>
       <input .form-control name=q value=#{qparam} placeholder="Search"
         title="Enter hledger search patterns to filter the data below">
+      $maybe period <- maybePeriod
+        <input hidden name=period value=#{period}>
       <div .input-group-btn>
         $if not (T.null qparam)
           <a href=@{here} .btn .btn-default title="Clear search terms">

--- a/hledger-web/templates/journal.hamlet
+++ b/hledger-web/templates/journal.hamlet
@@ -6,6 +6,20 @@ $if elem AddPermission perms
      data-toggle="modal" data-target="#addmodal" title="Add a new transaction to the journal">
     Add a transaction
 
+<p>
+  Report:
+  <a href=@?{ballink} title="Show balance report">Balance
+  <a href=@?{multiballink "yearly"}
+      title="Show daily multi-period balance report">Yearly
+  <a href=@?{multiballink "quarterly"}
+      title="Show daily multi-period balance report">Quarterly
+  <a href=@?{multiballink "monthly"}
+      title="Show daily multi-period balance report">Monthly
+  <a href=@?{multiballink "weekly"}
+      title="Show daily multi-period balance report">Weekly
+  <a href=@?{multiballink "daily"}
+      title="Show daily multi-period balance report">Daily
+
 <div .table-responsive>
   <table .transactionsreport .table .table-condensed>
     <thead>


### PR DESCRIPTION
This is a preview for a new feature of hledger-web.
It adds serving balance reports from hledger-web.

So far there remain some issues:
* I generate HTML with Lucid and then convert to Blaze. Instead I will add a new spreadsheet export backend Write.Html.Blaze. We can later discuss whether we want to keep Lucid, at all.
* Balance reports are currently integrated in the `defaultLayout`, which means there is always the sidebar. Do we want that? Of course, the user can hide the sidebar with `s` key. However, I found the query field useful in conjunction with the balance reports.
* Links to the balance report are only integrated in the Journal view for now. I could also move them to the query field component. Or above the Journal link in the sidebar.
* In a further commit I want to add radio buttons for the Layout type, maybe also the format type (TXT, CSV, FODS, HTML), maybe turn the period selection into a radio button, as well.
* The sidebar link to `Journal` does not maintain the current query. In the past I did it this way in order to have quick way out of restrictions posed by queries. However, all other accounts in the sidebar in the query and the hyperlinks behind dates in transactions in the `Register` page also maintain the query. Since I currently have the links to balance reports on the Journal page it would be nice if the top Journal link in the sidebar would also contain the query.