### PR TITLE
new layout bare-wide

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -120,6 +120,7 @@ instance Default AccountListMode where def = ALFlat
 data Layout = LayoutWide (Maybe Int)
             | LayoutTall
             | LayoutBare
+            | LayoutBareWide
             | LayoutTidy
   deriving (Eq, Show)
 
@@ -374,6 +375,7 @@ layoutopt rawopts = fromMaybe (LayoutWide Nothing) $ layout <|> column
                      , ("tall", LayoutTall)
                      , ("bare", LayoutBare)
                      , ("tidy", LayoutTidy)
+                     , ("bare-wide", LayoutBareWide)
                      ]
         -- For `--layout=elided,n`, elide to the given width
         (s,n) = break (==',') $ map toLower opt
@@ -382,7 +384,7 @@ layoutopt rawopts = fromMaybe (LayoutWide Nothing) $ layout <|> column
               c | Just w' <- readMay c -> Just w'
               _ -> usageError "width in --layout=wide,WIDTH must be an integer"
 
-        err = usageError "--layout's argument should be \"wide[,WIDTH]\", \"tall\", \"bare\", or \"tidy\""
+        err = usageError "--layout's argument should be \"wide[,WIDTH]\", \"tall\", \"bare\", \"bare-wide\", or \"tidy\""
 
 -- Get the period specified by any -b/--begin, -e/--end and/or -p/--period
 -- options appearing in the command line.

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -307,7 +307,7 @@ import Hledger.Write.Ods (printFods)
 import Hledger.Write.Html (Html, styledTableHtml, htmlAsLazyText, toHtml)
 import Hledger.Write.Spreadsheet (rawTableContent, headerCell,
             addHeaderBorders, addRowSpanHeader,
-            cellFromMixedAmount, cellsFromMixedAmount)
+            cellFromMixedAmount, cellsFromMixedAmount, cellFromAmount)
 import qualified Hledger.Write.Spreadsheet as Ods
 
 
@@ -598,6 +598,9 @@ renderComponent topaligned oneline opts (acctname, dep, total) (FormatField ljus
                   }
 
 
+headerWithoutBorders :: [Ods.Cell () text] -> [Ods.Cell Ods.NumLines text]
+headerWithoutBorders = map (\c -> c {Ods.cellBorder = Ods.noBorder})
+
 simpleDateSpanCell :: DateSpan -> Ods.Cell Ods.NumLines Text
 simpleDateSpanCell = Ods.defaultCell . showDateSpan
 
@@ -626,8 +629,11 @@ balanceReportAsSpreadsheet opts (items, total) =
     headers =
       addHeaderBorders $ map headerCell $
       "account" : case layout_ opts of
+        LayoutBareWide -> allCommodities
         LayoutBare -> ["commodity", "balance"]
         _          -> ["balance"]
+    allCommodities =
+        S.toAscList $ foldMap (\(_,_,_,ma) -> maCommodities ma) items
     rows ::
         RowClass -> BalanceReportItem ->
         [[Ods.Cell Ods.NumLines Text]]
@@ -639,6 +645,15 @@ balanceReportAsSpreadsheet opts (items, total) =
               cell $ renderBalanceAcct opts nbsp (name, dispName, dep) in
       addRowSpanHeader accountCell $
       case layout_ opts of
+      LayoutBareWide ->
+          let bopts =
+                machineFmt {
+                    displayCommodity = False,
+                    displayCommodityOrder = Just allCommodities
+                } in
+          [map (\bldAmt ->
+                fmap wbToText $ cellFromAmount bopts (amountClass rc, bldAmt)) $
+              showMixedAmountLinesPartsB bopts ma]
       LayoutBare ->
           map (\a -> [cell $ acommodity a, renderAmount rc $ mixedAmount a])
           . amounts $ mixedAmountStripCosts ma
@@ -662,29 +677,41 @@ balanceReportAsSpreadsheet opts (items, total) =
 multiBalanceReportAsCsv :: ReportOpts -> MultiBalanceReport -> CSV
 multiBalanceReportAsCsv opts@ReportOpts{..} report =
     (if transpose_ then transpose else id) $
-    rawTableContent $ header : body ++ totals
+    rawTableContent $ header ++ body ++ totals
   where
     (header, body, totals) =
-        multiBalanceReportAsSpreadsheetParts machineFmt opts report
+        multiBalanceReportAsSpreadsheetParts machineFmt opts
+            (allCommoditiesFromPeriodicReport $ prRows report) report
 
 -- | Render the Spreadsheet table rows (CSV, ODS, HTML) for a MultiBalanceReport.
 -- Returns the heading row, 0 or more body rows, and the totals row if enabled.
 multiBalanceReportAsSpreadsheetParts ::
-    AmountFormat -> ReportOpts -> MultiBalanceReport ->
-    ([Ods.Cell Ods.NumLines Text],
+    AmountFormat -> ReportOpts ->
+    [CommoditySymbol] -> MultiBalanceReport ->
+    ([[Ods.Cell Ods.NumLines Text]],
      [[Ods.Cell Ods.NumLines Text]],
      [[Ods.Cell Ods.NumLines Text]])
-multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..} (PeriodicReport colspans items tr) =
-    (headers, concatMap fullRowAsTexts items, addTotalBorders totalrows)
+multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..}
+  allCommodities (PeriodicReport colspans items tr) =
+    (allHeaders, concatMap fullRowAsTexts items, addTotalBorders totalrows)
   where
     accountCell label =
         (Ods.defaultCell label) {Ods.cellClass = Ods.Class "account"}
     hCell cls label = (headerCell label) {Ods.cellClass = Ods.Class cls}
+    allHeaders =
+      case layout_ of
+      LayoutBareWide ->
+          [headerWithoutBorders $
+              Ods.emptyCell :
+              concatMap (Ods.horizontalSpan allCommodities) dateHeaders,
+           headers]
+      _ -> [headers]
     headers =
       addHeaderBorders $
       hCell "account" "account" :
       case layout_ of
       LayoutTidy -> map headerCell tidyColumnLabels
+      LayoutBareWide -> dateHeaders >> map headerCell allCommodities
       LayoutBare -> headerCell "commodity" : dateHeaders
       _          -> dateHeaders
     dateHeaders =
@@ -705,7 +732,7 @@ multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..} (PeriodicReport col
                 rowAsText Total simpleDateSpanCell tr
     rowAsText rc dsCell =
         map (map (fmap wbToText)) .
-        multiBalanceRowAsCellBuilders fmt opts colspans rc dsCell
+        multiBalanceRowAsCellBuilders fmt opts colspans allCommodities rc dsCell
 
 tidyColumnLabels :: [Text]
 tidyColumnLabels =
@@ -725,10 +752,12 @@ multiBalanceReportAsSpreadsheet ::
   ((Int, Int), [[Ods.Cell Ods.NumLines Text]])
 multiBalanceReportAsSpreadsheet ropts mbr =
   let (header,body,total) =
-            multiBalanceReportAsSpreadsheetParts oneLineNoCostFmt ropts mbr
+            multiBalanceReportAsSpreadsheetParts oneLineNoCostFmt ropts
+                (allCommoditiesFromPeriodicReport $ prRows mbr) mbr
   in  (if transpose_ ropts then swap *** Ods.transpose else id) $
-      ((1, case layout_ ropts of LayoutWide _ -> 1; _ -> 0),
-            header : body ++ total)
+      ((case layout_ ropts of LayoutBareWide -> 2; _ -> 1,
+        case layout_ ropts of LayoutWide _ -> 1; _ -> 0),
+            header ++ body ++ total)
 
 
 -- | Render a multi-column balance report as plain text suitable for console output.
@@ -799,19 +828,24 @@ multiBalanceReportAsTable opts@ReportOpts{summary_only_, average_, balanceaccum_
      (concat rows)
   where
     colheadings = ["Commodity" | layout_ opts == LayoutBare]
-                  ++ (if not summary_only_ then map (reportPeriodName balanceaccum_ spans) spans else [])
+                  ++ (if not summary_only_
+                        then case layout_ opts of
+                                LayoutBareWide -> spans >> allCommodities
+                                _ -> map (reportPeriodName balanceaccum_ spans) spans
+                        else [])
                   ++ ["  Total" | multiBalanceHasTotalsColumn opts]
                   ++ ["Average" | average_]
+    allCommodities = allCommoditiesFromPeriodicReport items
     (accts, rows) = unzip $ fmap fullRowAsTexts items
       where
         fullRowAsTexts row = (replicate (length rs) (renderacct row), rs)
           where
-            rs = multiBalanceRowAsText opts row
+            rs = multiBalanceRowAsText opts allCommodities row
             renderacct row' = T.replicate (prrIndent row' * 2) " " <> prrDisplayName row'
     addtotalrow
       | no_total_ opts = id
       | otherwise =
-        let totalrows = multiBalanceRowAsText opts tr
+        let totalrows = multiBalanceRowAsText opts allCommodities tr
             rowhdrs = Group NoLine $ map Header $ totalRowHeadingText : replicate (length totalrows - 1) ""
             colhdrs = Header [] -- unused, concatTables will discard
         in (flip (concatTables SingleLine) $ Table rowhdrs colhdrs totalrows)
@@ -820,12 +854,17 @@ multiBalanceReportAsTable opts@ReportOpts{summary_only_, average_, balanceaccum_
     multiColumnTableInterRowBorder    = NoLine
     multiColumnTableInterColumnBorder = if pretty_ opts then SingleLine else NoLine
 
+allCommoditiesFromPeriodicReport ::
+    [PeriodicReportRow a MixedAmount] -> [CommoditySymbol]
+allCommoditiesFromPeriodicReport =
+    S.toAscList . foldMap (foldMap maCommodities . prrAmounts)
+
 multiBalanceRowAsCellBuilders ::
-    AmountFormat -> ReportOpts -> [DateSpan] ->
+    AmountFormat -> ReportOpts -> [DateSpan] -> [CommoditySymbol] ->
     RowClass -> (DateSpan -> Ods.Cell Ods.NumLines Text) ->
     PeriodicReportRow a MixedAmount ->
     [[Ods.Cell Ods.NumLines WideBuilder]]
-multiBalanceRowAsCellBuilders bopts ropts@ReportOpts{..} colspans
+multiBalanceRowAsCellBuilders bopts ropts@ReportOpts{..} colspans allCommodities
       rc renderDateSpanCell (PeriodicReportRow _acct as rowtot rowavg) =
     case layout_ of
       LayoutWide width -> [fmap (cellFromMixedAmount bopts{displayMaxWidth=width}) clsamts]
@@ -836,6 +875,8 @@ multiBalanceRowAsCellBuilders bopts ropts@ReportOpts{..} colspans
                            . transpose                         -- each row becomes a list of Text quantities
                            . map (cellsFromMixedAmount bopts{displayCommodity=False, displayCommodityOrder=Just cs, displayMinWidth=Nothing})
                            $ clsamts
+      LayoutBareWide   -> [concatMap (cellsFromMixedAmount bopts{displayCommodity=False, displayCommodityOrder=Just allCommodities, displayMinWidth=Nothing})
+                            $ clsamts]
       LayoutTidy       -> concat
                            . zipWith (map . addDateColumns) colspans
                            . map ( zipWith (\c a -> [wbCell c, a]) cs
@@ -878,16 +919,20 @@ multiBalanceHasTotalsColumn :: ReportOpts -> Bool
 multiBalanceHasTotalsColumn ropts =
     row_total_ ropts && balanceaccum_ ropts `notElem` [Cumulative, Historical]
 
-multiBalanceRowAsText :: ReportOpts -> PeriodicReportRow a MixedAmount -> [[WideBuilder]]
-multiBalanceRowAsText opts =
+multiBalanceRowAsText ::
+    ReportOpts -> [CommoditySymbol] -> PeriodicReportRow a MixedAmount -> [[WideBuilder]]
+multiBalanceRowAsText opts allCommodities =
     rawTableContent .
-    multiBalanceRowAsCellBuilders oneLineNoCostFmt{displayColour=color_ opts} opts []
+    multiBalanceRowAsCellBuilders oneLineNoCostFmt{displayColour=color_ opts}
+        opts [] allCommodities
         Value simpleDateSpanCell
 
-multiBalanceRowAsCsvText :: ReportOpts -> [DateSpan] -> PeriodicReportRow a MixedAmount -> [[T.Text]]
-multiBalanceRowAsCsvText opts colspans =
+multiBalanceRowAsCsvText ::
+    ReportOpts -> [DateSpan] -> [CommoditySymbol] ->
+    PeriodicReportRow a MixedAmount -> [[T.Text]]
+multiBalanceRowAsCsvText opts colspans allCommodities =
     map (map (wbToText . Ods.cellContent)) .
-    multiBalanceRowAsCellBuilders machineFmt opts colspans
+    multiBalanceRowAsCellBuilders machineFmt opts colspans allCommodities
         Value simpleDateSpanCell
 
 


### PR DESCRIPTION
This is a draft for a new type of layout. This is the original reason why I started to work on hledger export functions ...

I called it `bare-wide`, because it is like `bare` but the amounts are put in one column per commodity. Sometimes it requires two header rows and horizontally merged headers for dates. I implemented it for HTML and FODS output of plain balance, multi-period balance and compound balances. Not implemented for budget reports, but those reports support only bare and non-bare layouts, anyway.

I thought about alternative names like `sub` (one sub-column per commodity), `columns`, `separate`. Maybe you have better ideas.

I have also some draft code for a table type with labels for header groups. This could enable layout bare-wide for the text outputs. This draft code is not contained in this pull request.


I found a command in `multiBalanceReportHtmlRows` that reads:
~~~~
-- TODO: should the commodity_column be displayed as a subaccount in this case as well?
~~~~
I do not know whether it is still relevant. I have moved it to `compoundBalanceReportAsHtml` but it might be even more confusing there.