### PR TITLE
imp: web: preserve sidebar position during navigation

### DIFF
--- a/hledger-web/CHANGES.md
+++ b/hledger-web/CHANGES.md
@@ -29,6 +29,9 @@ Improvements
 
 - Allow yesod-static 1.6.1.1 and later again.
 
+- In hledger-web, account/register/journal links now preserve the sidebar
+  scroll position when JavaScript is available.
+
 - Uses hledger 1.99.2.
 
 

--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -92,7 +92,9 @@ ul {
 }
 
 #sidebar-menu {
-    overflow:hidden;
+    max-height: calc(100vh - 5.5em);
+    overflow-x:hidden;
+    overflow-y:auto;
     border-right: 1px solid #ebebeb;
 }
 #sidebar-menu .main-menu {

--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -4,35 +4,12 @@
 // STARTUP
 
 $(document).ready(function() {
+  hledgerInitGlobal();
+  hledgerInitPage();
+  hledgerInitAjaxNavigation();
+});
 
-  // add form helpers XXX move to addForm ?
-
-  // date picker
-  // http://bootstrap-datepicker.readthedocs.io/en/latest/options.html
-  var dateEl = $('#dateWrap').datepicker({
-    showOnFocus: false,
-    autoclose: true,
-    format: 'yyyy-mm-dd',
-    todayHighlight: true,
-    weekStart: 1 // Monday
-  });;
-
-  // focus and pre-fill the add form whenever it is shown
-  $('#addmodal')
-    .on('shown.bs.modal', function() {
-      addformFocus();
-    })
-    .on('hidden.bs.modal', function() {
-      // close the date picker if open
-      dateEl.datepicker('hide');
-    });
-
-  // ensure that the keypress listener on the final amount input is always active
-  $('#addform')
-    .on('focus', '.amount-input:last', function() {
-      addformLastAmountBindKey();
-    });
-
+function hledgerInitGlobal() {
   // keyboard shortcuts
   // 'body' seems to hold focus better than document in FF
   $('body').bind('keydown', 'h',       function(){ $('#helpmodal').modal('toggle'); return false; });
@@ -55,7 +32,154 @@ $(document).ready(function() {
   $('[data-toggle="offcanvas"]').click(function () {
       $('.row-offcanvas').toggleClass('active');
   });
-});
+}
+
+function hledgerInitPage() {
+
+  // add form helpers XXX move to addForm ?
+
+  // date picker
+  // http://bootstrap-datepicker.readthedocs.io/en/latest/options.html
+  var dateEl = $('#dateWrap').datepicker({
+    showOnFocus: false,
+    autoclose: true,
+    format: 'yyyy-mm-dd',
+    todayHighlight: true,
+    weekStart: 1 // Monday
+  });;
+
+  // focus and pre-fill the add form whenever it is shown
+  $('#addmodal')
+    .off('shown.bs.modal.hledger hidden.bs.modal.hledger')
+    .on('shown.bs.modal.hledger', function() {
+      addformFocus();
+    })
+    .on('hidden.bs.modal.hledger', function() {
+      // close the date picker if open
+      dateEl.datepicker('hide');
+    });
+
+  // ensure that the keypress listener on the final amount input is always active
+  $('#addform')
+    .off('focus.hledger')
+    .on('focus.hledger', '.amount-input:last', function() {
+      addformLastAmountBindKey();
+    });
+}
+
+function hledgerInitAjaxNavigation() {
+  if (!window.history || !window.history.pushState || !window.DOMParser || !window.URL || !window.location.origin) {
+    return;
+  }
+
+  $(document).off('click.hledgerAjaxNavigation')
+    .on('click.hledgerAjaxNavigation', '#sidebar-menu a[href], #main-content a[href]', function(ev) {
+      if (!hledgerAjaxCanHandleLink(this, ev)) {
+        return;
+      }
+      ev.preventDefault();
+      hledgerAjaxNavigate(this.href, true);
+    });
+
+  $(window).off('popstate.hledgerAjaxNavigation')
+    .on('popstate.hledgerAjaxNavigation', function() {
+      hledgerAjaxNavigate(window.location.href, false);
+    });
+}
+
+function hledgerAjaxCanHandleLink(link, ev) {
+  if (ev.isDefaultPrevented() || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) {
+    return false;
+  }
+  if (link.target && link.target !== '_self') {
+    return false;
+  }
+
+  var url = new URL(link.href, window.location.href);
+  if (url.origin !== window.location.origin) {
+    return false;
+  }
+
+  var path = url.pathname.replace(/\/$/, '');
+  return path === hledgerAjaxRoutePath('/journal') || path === hledgerAjaxRoutePath('/register');
+}
+
+function hledgerAjaxRoutePath(route) {
+  var base = new URL(document.hledgerWebBaseurl, window.location.href);
+  var basePath = base.pathname.replace(/\/$/, '');
+  return basePath + route;
+}
+
+function hledgerAjaxNavigate(href, pushHistory) {
+  $.ajax({
+    url: href,
+    method: 'GET',
+    dataType: 'html',
+    cache: false
+  }).done(function(html) {
+    if (!hledgerAjaxApplyPage(html, href, pushHistory)) {
+      window.location.href = href;
+    }
+  }).fail(function() {
+    window.location.href = href;
+  });
+}
+
+function hledgerAjaxApplyPage(html, href, pushHistory) {
+  var doc = new DOMParser().parseFromString(html, 'text/html');
+  var newMain = doc.querySelector('#main-content');
+  var newSidebar = doc.querySelector('#sidebar-menu');
+  if (!newMain || !newSidebar) {
+    return false;
+  }
+
+  var $oldSidebar = $('#sidebar-menu');
+  var sidebarScrollTop = $oldSidebar.scrollTop();
+  var $newMain = $(newMain);
+  var scripts = $newMain.find('script').remove().toArray();
+
+  $('#main-content').replaceWith($newMain);
+  $oldSidebar.find('.main-menu').replaceWith($(newSidebar).find('.main-menu'));
+  $oldSidebar.scrollTop(sidebarScrollTop);
+
+  if (doc.title) {
+    document.title = doc.title;
+  }
+  if (pushHistory) {
+    window.history.pushState({hledgerAjax: true}, doc.title || '', href);
+  }
+
+  hledgerInitPage();
+  hledgerAjaxRunScripts(scripts);
+  hledgerHighlightHash();
+  hledgerScrollToHashOrTop();
+  return true;
+}
+
+function hledgerAjaxRunScripts(scripts) {
+  $.each(scripts, function(_i, script) {
+    if (script.src) {
+      $.ajax({url: script.src, dataType: 'script', async: false});
+    } else {
+      $.globalEval(script.text || script.textContent || script.innerHTML || '');
+    }
+  });
+}
+
+function hledgerHighlightHash() {
+  $('.highlighted').removeClass('highlighted');
+  if (window.location.hash && $(window.location.hash)[0]) {
+    $(window.location.hash).addClass('highlighted');
+  }
+}
+
+function hledgerScrollToHashOrTop() {
+  if (window.location.hash && $(window.location.hash)[0]) {
+    window.scrollTo(0, $(window.location.hash).offset().top);
+  } else {
+    window.scrollTo(0, 0);
+  }
+}
 
 //----------------------------------------------------------------------
 // ADD FORM


### PR DESCRIPTION
This is an exploratory draft PR for hledger 2.x `main`.

When reviewing a large chart of accounts in hledger-web, clicking account links currently reloads the full page and resets the account sidebar position. This patch keeps the existing server-rendered links and progressively enhances same-origin `/journal` and `/register` navigation when JavaScript is available:

- keep ordinary `href`s for no-JS / failed-JS fallback behavior
- fetch the target page as HTML
- replace only `#main-content`
- refresh the sidebar account table so the active account highlight updates
- preserve the existing sidebar container and `scrollTop`
- use `history.pushState` / `popstate` for URLs and browser back/forward

I also made `#sidebar-menu` a bounded vertical scroll container.

Related context:

- #200 includes "Both sidebar and entries should have their own scroll bars."
- #33 says hledger-web should remain usable with JavaScript disabled; this keeps normal links as the fallback.
- #316 was a larger REST API / JavaScript client idea; this intentionally avoids that scope.

Checks run locally:

- `node -c hledger-web/static/hledger.js`
- `git diff --check`
- `cabal v2-build hledger-web --enable-tests --allow-newer --constraint='persistent >=2.17'`
- `cabal v2-test hledger-web:apptest --allow-newer --constraint='persistent >=2.17'`

The Cabal build/test needed the `persistent >=2.17` constraint because this machine only has GHC 9.14.1, and the default plan selected `persistent-2.11.0.4`, which did not compile with this toolchain. With the local dependency workaround, hledger-web built and its test suite passed: 4 examples, 0 failures.

Manual smoke check:

- Ran the patched hledger-web against a generated local journal with 81 accounts.
- Confirmed the patched `hledger.js` and `hledger.css` were served.
- Manually tried sidebar account navigation in the in-app browser and found it worked well in first use.

Still worth checking before considering this ready:

- more real-world use on larger account trees
- browser back/forward behavior
- register chart rendering after AJAX navigation
- add-transaction modal behavior when hledger-web is not in view-only mode
- sidebar hidden/shown cookie behavior
- behavior with a non-root `--base-url`

AI assistance disclosure:

This patch and PR text were prepared with OpenAI/Codex assistance. Approximate usage: several interactive Codex turns for research, patch drafting/refinement, local testing, and PR preparation. I understand the project currently prefers not to accept OpenAI-assisted work; I am opening this as a draft for review/discussion and to learn whether this direction is useful.
