### PR TITLE
balance: enhanced --no-elide 

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -333,14 +333,20 @@ markAccountBoring ReportSpec{_rsQuery=query,_rsReportOpts=ropts}
 
         qdepth = fromMaybe maxBound . getAccountNameClippedDepth depthspec $ aname acct
         balance = maybeStripPrices . case accountlistmode_ ropts of
-            ALTree | d == qdepth -> bdincludingsubs
-            _                    -> bdexcludingsubs
+            ALTree ->
+                if d == qdepth
+                  then bdincludingsubs
+                  else bdexcludingsubs
+            ALFlat ->
+                if no_elide_ ropts
+                  then bdincludingsubs
+                  else bdexcludingsubs
 
     -- Accounts which don't have enough interesting subaccounts
     isBoringParent :: Account a -> Bool
     isBoringParent acct = case accountlistmode_ ropts of
         ALTree -> notEnoughSubs || droppedAccount
-        ALFlat -> True
+        ALFlat -> not $ no_elide_ ropts
       where
         notEnoughSubs = length interestingSubs < minimumSubs
         droppedAccount = accountNameLevel (aname acct) <= drop_ ropts
@@ -431,7 +437,7 @@ buildReportRows makeRow ropts = mkRows True (-drop_ ropts) 0
     allBoring a = aboring a && all allBoring (asubs a)
     balance = case accountlistmode_ ropts of
         ALTree -> bdincludingsubs
-        ALFlat -> bdexcludingsubs
+        ALFlat -> if no_elide_ ropts then bdincludingsubs else bdexcludingsubs
 
     displayedName d boringParents name
         | d == 0 && name == "root" = DisplayName "..." "..." 0

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -181,7 +181,7 @@ uiInitialState uopts0@UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpe
             _rsReportOpts=ropts{
                depth_    = queryDepth $ _rsQuery rspec,  -- query's depth part
                period_   = periodfromoptsandargs,       -- query's date part
-               no_elide_ = True,  -- avoid squashing boring account names, for a more regular tree (unlike hledger)
+               no_elide_ = accountlistmode_ ropts == ALTree,   -- avoid squashing boring account names, for a more regular tree (unlike hledger)
                empty_    = not $ empty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
                declared_ = True  -- always show declared accounts even if unused
                }

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -206,7 +206,7 @@ setList = set accountlistmode ALFlat
 
 -- | Toggle between flat and tree mode. If current mode is unspecified/default, assume it's flat.
 toggleTree :: UIState -> UIState
-toggleTree = over accountlistmode toggleTreeMode
+toggleTree = over no_elide not . over accountlistmode toggleTreeMode
   where
     toggleTreeMode ALTree = ALFlat
     toggleTreeMode ALFlat = ALTree

--- a/hledger/test/balance/219.test
+++ b/hledger/test/balance/219.test
@@ -5,6 +5,7 @@ Ending balances (historical) in 2013-01:
 
                  || 2013-01-31 
 =================++============
+ assets          ||         10 
  assets:checking ||         10 
 
 # ** 2. multiple flags ending with --tree, equivalent to --tree


### PR DESCRIPTION
I have mapped `--no-elide` to what I formerly implemented for the `--include-parent` option.
I now see the problem: The included parent accounts do not show the sum of the subaccounts.
This is what worked, when I added the `--full-path` option to the Tree Mode.