### PR TITLE
instance Show Account also shows sub-accounts

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -75,6 +75,8 @@ instance Show a => Show (Account a) where
       . showString (if aboring acct then "y" else "n")
       . showString ", adata:"
       . shows (adata acct)
+      . showString ", asubs:"
+      . shows (asubs acct)
       . showChar ')'
 
 instance Eq (Account a) where


### PR DESCRIPTION
I was confused for days because code comments talk about account trees and according functions morally have to deal with trees not individual accounts. However, the type is named `Account` and it does not show sub accounts in debug output.

I added showing the sub-accounts to `instance Show Account`. But maybe, for some debug situations this is too noisy?
