### PR TITLE
hledger-web: rename Posting ptype to preal in the OpenAPI spec

### DIFF
--- a/hledger-web/config/openapi.yaml
+++ b/hledger-web/config/openapi.yaml
@@ -100,10 +100,10 @@ paths:
                         - pdate
                         - pdate2
                         - poriginal
+                        - preal
                         - pstatus
                         - ptags
                         - ptransaction_
-                        - ptype
                         properties:
                           paccount: {}
                           pamount:
@@ -189,10 +189,10 @@ paths:
                           pdate: {}
                           pdate2: {}
                           poriginal: {}
+                          preal: {}
                           pstatus: {}
                           ptags: {}
                           ptransaction_: {}
-                          ptype: {}
                     tprecedingcomment: {}
                     tsourcepos:
                       items:
@@ -556,10 +556,10 @@ paths:
                             - pdate
                             - pdate2
                             - poriginal
+                            - preal
                             - pstatus
                             - ptags
                             - ptransaction_
-                            - ptype
                             properties:
                               paccount: {}
                               pamount:
@@ -603,10 +603,10 @@ paths:
                               pdate: {}
                               pdate2: {}
                               poriginal: {}
+                              preal: {}
                               pstatus: {}
                               ptags: {}
                               ptransaction_: {}
-                              ptype: {}
                         tprecedingcomment: {}
                         tsourcepos:
                           items:


### PR DESCRIPTION
`Posting`'s `ptype` field was renamed to `preal` in 1.50 (hledger-lib CHANGES.md:89, hledger-web CHANGES.md:82), but `openapi.yaml` still requires `ptype` and never mentions `preal`. Since the API always emits `preal` and never `ptype`, a client generated or validated against the spec rejects every posting.

Verified against the encoder rather than the changelog alone — `postingKV` in `hledger-lib/Hledger/Data/Json.hs:123` emits:

```
paccount pamount pbalanceassertion pcomment pdate pdate2 poriginal preal pstatus ptags ptransaction_
```

which after this change is exactly the spec's `required` list. That was the only remaining mismatch I could find between the spec and the current types.

The entries are kept alphabetical, so `preal` follows `poriginal` rather than sitting where `ptype` was.

Scoped to `openapi.yaml` deliberately: `ptype` was reused as a lot-tracking tag name in `Hledger/Data/Lots.hs` (per hledger-lib CHANGES.md:90, renamed "to avoid confusion with the new `ptype` tag"), so a repo-wide rename would be wrong. There are 101 occurrences of `ptype` in the tree and only these 4 belong to the spec.

Refs #2459

The originally reported drift there looks like it was covered by #2554; this one appeared afterwards. `hledger-web.m4.md` also has two stale `"ptype": "RegularPosting"` lines in a JSON example — happy to include those, or leave them for the next embedded-manual regeneration, whichever you prefer.
