### PR TITLE
fix:web: render add-form completion suggestions as text

### DIFF
--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -130,7 +130,7 @@ function addformAddPosting() {
   // or it will recursively add helper elements for those, causing confusion (#2215).
   newrow.find('.tt-hint').remove();
   newrow.find('.tt-input').removeClass('tt-input');
-  accountfield.typeahead({ highlight: true }, { source: globalThis.accountsCompleter.ttAdapter() });
+  accountfield.typeahead({ highlight: true }, { source: globalThis.accountsCompleter.ttAdapter(), templates: { suggestion: globalThis.suggestionTemplate } });
 
   // Add the new row to the page.
   $('#addform .account-postings').append(newrow);

--- a/hledger-web/templates/add-form.hamlet
+++ b/hledger-web/templates/add-form.hamlet
@@ -20,9 +20,16 @@
     });
     globalThis.accountsCompleter.initialize();
 
+    // use template to ensure proper escaping
+    globalThis.suggestionTemplate = function(d) {
+      var p = document.createElement('p');
+      p.textContent = d.value;
+      return p;
+    };
+
     // Attach the completers to the initial form inputs.
-    jQuery('input[name=description]').typeahead({ highlight: true }, { source: globalThis.descriptionsCompleter.ttAdapter() });
-    jQuery('input[name=account]'    ).typeahead({ highlight: true }, { source: globalThis.accountsCompleter.ttAdapter() });
+    jQuery('input[name=description]').typeahead({ highlight: true }, { source: globalThis.descriptionsCompleter.ttAdapter(), templates: { suggestion: globalThis.suggestionTemplate } });
+    jQuery('input[name=account]'    ).typeahead({ highlight: true }, { source: globalThis.accountsCompleter.ttAdapter(), templates: { suggestion: globalThis.suggestionTemplate } });
   });
 
   const utf8textdecoder = new TextDecoder();


### PR DESCRIPTION
Typeahead's default suggestion template concatenates each value into HTML. 

An account name or transaction description containing markup is parsed as markup when it appears in the add form's completion list.

Journal data is not always written by the person reading it: it arrives from imported csv, shared files, or another tool appending to a journal.

To reproduce, put an account name containing an event handler in a journal, open the add form, and type the first few characters of that name.

To fix, pass a template at all three places a completer is attached: the description field, the account fields, and a newly added posting row.

AI usage: Claude Fable 5, ~10k output tokens

---

This was briefly public, then redacted pending a full advisory and fix. See [GHSA-538p-cvc4-4qjm](https://github.com/simonmichael/hledger/security/advisories/GHSA-538p-cvc4-4qjm) for the full disclosure, and [hledger 1.52.2](https://github.com/simonmichael/hledger/releases/tag/1.52.2) for the fix.