### PR TITLE
Pass addon arguments through verbatim, as documented

### DIFF
--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -280,6 +280,13 @@ main = handleExit $ withGhcDebug' $ do
     mbuiltincmdaction = findBuiltinCommand cmdname
     effectivemode = maybe (mainmode []) fst mbuiltincmdaction
 
+    -- The required-value flags to pre-check on the final command line.
+    -- For an addon command, only hledger's general flags; any other flags are the addon's.
+    -- Otherwise, the flags supported by the command's mode.
+    finalreqvalflagargs
+      | isaddoncmd = generalReqValFlagArgs
+      | otherwise  = modeReqValFlagArgs effectivemode
+
   dbgio "cli args with command first and no cli-specific opts" cliargswithcmdfirstwithoutclispecific
   when isaliascmd $
     dbg1IO "expanded command alias" (cmdarg, (effectivecmdarg, aliasargs))
@@ -354,7 +361,7 @@ main = handleExit $ withGhcDebug' $ do
 
   -- Run cmdargs on command name + supported conf general args + conf subcommand args + cli args to get the final options.
   -- A bad flag or flag argument will cause the program to exit with an error here.
-  let rawopts = cmdargsParse "final command line" (mainmode addons) finalargs
+  let rawopts = cmdargsParseWith finalreqvalflagargs "final command line" (mainmode addons) finalargs
 
   ---------------------------------------------------------------
   seq rawopts $  -- order debug output
@@ -506,16 +513,25 @@ argsToCliOpts args addons = do
 -- (useful when cmdargsParse is called more than once).
 -- If parsing fails, exit the program with an informative error message.
 cmdargsParse :: String -> Mode RawOpts -> [String] -> RawOpts
-cmdargsParse desc m args0 = process m (ensureDebugFlagHasVal (checkReqValFlagArgsHaveValues args0))
+cmdargsParse = cmdargsParseWith reqValFlagArgs
+
+-- | Like 'cmdargsParse', but pre-check for missing values only on the given required-value
+-- flag args, rather than on every one known to hledger. Use this once the command being run
+-- is known, so that flags belonging to other commands are left for cmdargs (or an addon).
+cmdargsParseWith :: [String] -> String -> Mode RawOpts -> [String] -> RawOpts
+cmdargsParseWith reqvalflagargs desc m args0 =
+  process m (ensureDebugFlagHasVal (checkReqValFlagArgsHaveValues reqvalflagargs args0))
   & either
     (\e -> error' $ e <> "\n* while parsing the following args, " <> desc <> ":\n*  " <> unwords (map quoteIfNeeded args0))
     (dbgMsg verboseDebugLevel ("cmdargs: parsing " <> desc <> ": " <> show args0))
   -- XXX better error message when cmdargs fails (eg spaced/quoted/malformed flag values) ?
 
--- | Check that each known required-value flag in the arg list is followed by a value, not another
--- known flag. If a required-value flag is at the end of the args, or is followed by something that
--- looks like a known hledger flag, abort with a usage error naming the offending flag. Returns the
--- args unchanged.
+-- | Check that each of the given required-value flags appearing in the arg list is followed by a
+-- value, not another known flag. If such a flag is at the end of the args, or is followed by
+-- something that looks like a known hledger flag, abort with a usage error naming the offending
+-- flag. Returns the args unchanged.
+--
+-- Scanning stops at the first "--", since cmdargs treats everything after it as positional args.
 --
 -- Joined forms like -fFILE or --file=FILE are single tokens, so they bypass the check.
 -- A bare "-" (commonly used to mean stdin), and prefixed forms like "csv:-", are allowed as values.
@@ -523,20 +539,21 @@ cmdargsParse desc m args0 = process m (ensureDebugFlagHasVal (checkReqValFlagArg
 -- allowed, so we don't break legitimate dash-prefixed value syntax.
 -- Flags whose value-ness varies by command (ambiguousFlagArgs, eg -m/-p) are not checked here,
 -- since the command is not yet known; cmdargs validates them per-command.
-checkReqValFlagArgsHaveValues :: [String] -> [String]
-checkReqValFlagArgsHaveValues = go
+checkReqValFlagArgsHaveValues :: [String] -> [String] -> [String]
+checkReqValFlagArgsHaveValues reqvalflagargs = go
   where
     -- --debug is declared as flagReq but treated as optional-value via ensureDebugFlagHasVal,
     -- so don't validate it here.
     -- Ambiguous flags (required-value in some commands, valueless in others, eg -m/-p) are also
     -- skipped, since we can't know here which command's meaning applies; cmdargs will check them.
-    checkable a = a `elem` reqValFlagArgs && a /= "--debug" && a `notElem` ambiguousFlagArgs
+    checkable a = a `elem` reqvalflagargs && a /= "--debug" && a `notElem` ambiguousFlagArgs
     knownFlags = noValFlagArgs `union` reqValFlagArgs `union` optValFlagArgs
     looksLikeKnownFlag b =
          b `elem` knownFlags
       || any (`isPrefixOf` b) longReqValFlagArgs_
       || any (`isPrefixOf` b) longOptValFlagArgs_
     go [] = []
+    go as@("--":_) = as
     go [a]
       | checkable a = usageError $ a <> " needs a value, none provided"
       | otherwise = [a]
@@ -709,6 +726,14 @@ optValCommandFlagNames = [f | (f,i) <- concatMap toFlagInfos commandFlags, isOpt
 noValFlagArgs  = map toFlagArg $ noValGeneralFlagNames  `union` (noValCommandFlagNames  \\ generalFlagNames)
 reqValFlagArgs = map toFlagArg $ reqValGeneralFlagNames `union` (reqValCommandFlagNames \\ generalFlagNames)
 optValFlagArgs = map toFlagArg $ optValGeneralFlagNames `union` (optValCommandFlagNames \\ generalFlagNames)
+
+-- The required-value flag args belonging to hledger's general flags.
+generalReqValFlagArgs = map toFlagArg reqValGeneralFlagNames
+
+-- The required-value flag args supported by this mode or its immediate subcommands.
+modeReqValFlagArgs :: Mode RawOpts -> [String]
+modeReqValFlagArgs m = filter (`elem` modeflagargs) reqValFlagArgs
+  where modeflagargs = map toFlagArg $ concatMap flagNames $ modeAndSubmodeFlags m
 
 -- Flag args whose value-ness is ambiguous across commands: required-value in some command(s)
 -- but valueless (no-value) in others. Their meaning can't be known before the command is

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -452,18 +452,24 @@ main = handleExit $ withGhcDebug' $ do
     -- 6.5. external addon command found - run it,
     -- passing any cli arguments written after the command name
     -- and any command-specific opts from the config file.
-    -- The first "--" argument, which sometimes must be used in the command line
-    -- to hide addon-specific opts from hledger's cmdargs parsing, is consumed here;
-    -- any later "--" arguments are the addon's, and are passed on.
-    -- Anything written after that first "--" is passed on untouched, including
+    -- The first "--" argument in each source -- a config file section, a command
+    -- alias, or the command line -- is hledger's separator and is consumed here;
+    -- any later "--" arguments in that source are the addon's, and are passed on.
+    -- Anything written after a source's first "--" is passed on untouched, including
     -- args which would otherwise look like hledger's own cli-specific options.
     -- Arguments written before the command name, and general opts from the config file,
     -- are not passed since we can't be sure they're supported.
     | isaddoncmd -> do
         let
-          (cliargsbeforesep, cliargsaftersep) = breakAtFirstSeparator cliargswithoutcmd
-          addonargs0 = supportedgenargsfromconf <> confcmdargs0 <> aliasargs <> cliargsbeforesep
-          addonargs = dropCliSpecificOpts addonargs0 <> cliargsaftersep
+          -- Each argument source carries its own separator: the first "--" in a
+          -- source is hledger's and is consumed, and whatever follows it in that
+          -- source is passed on untouched. Splitting per source rather than over
+          -- the concatenation matters, or a "--" in a config section or alias
+          -- would suppress the stripping of hledger's own options off the
+          -- command line, leaking eg "--conf FILE" to the addon.
+          consumeSeparator as = let (bs, cs) = breakAtFirstSeparator as in dropCliSpecificOpts bs <> cs
+          addonargs = concatMap consumeSeparator
+                        [supportedgenargsfromconf, confcmdargs0, aliasargs, cliargswithoutcmd]
           addonexe = printf "%s-%s" progname cmdname :: String
           shellcmd = unwords $ map quoteForCommandLine $ addonexe : addonargs
         dbgio "addon command selected" cmdname

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -328,12 +328,13 @@ main = handleExit $ withGhcDebug' $ do
       | isaddoncmd = []
       | otherwise  = dropUnsupportedOpts effectivemode confothergenargs
     excludedgenargsfromconf = confothergenargs \\ supportedgenargsfromconf
-    confcmdargs
+    confcmdargs0
       | null cmdname = []
-      | otherwise =
-          confLookup cmdname conf
-          & replaceNumericFlags
-          & if isaddoncmd then ("--":) else id
+      | otherwise    = confLookup cmdname conf & replaceNumericFlags
+    -- For an addon, prepend a "--" so that cmdargs parses the addon's own flags as
+    -- positional args rather than rejecting them. This separator is for parsing only;
+    -- it is not part of the args passed on to the addon.
+    confcmdargs = confcmdargs0 & if isaddoncmd then ("--":) else id
 
   when (isJust mconffile) $ do
     unless (null confdroppedgenargs) $
@@ -450,16 +451,15 @@ main = handleExit $ withGhcDebug' $ do
     -- 6.5. external addon command found - run it,
     -- passing any cli arguments written after the command name
     -- and any command-specific opts from the config file.
-    -- Any "--" arguments, which sometimes must be used in the command line
-    -- to hide addon-specific opts from hledger's cmdargs parsing,
-    -- (and are also accepted in the config file, though not required there),
-    -- will be removed.
-    -- (hledger does not preserve -- arguments)
+    -- The first "--" argument, which sometimes must be used in the command line
+    -- to hide addon-specific opts from hledger's cmdargs parsing, is consumed here;
+    -- any later "--" arguments are the addon's, and are passed on.
     -- Arguments written before the command name, and general opts from the config file,
     -- are not passed since we can't be sure they're supported.
     | isaddoncmd -> do
         let
-          addonargs0 = filter (/="--") $ supportedgenargsfromconf <> confcmdargs <> aliasargs <> cliargswithoutcmd
+          (cliargsbeforesep, cliargsaftersep) = breakAtFirstSeparator cliargswithoutcmd
+          addonargs0 = supportedgenargsfromconf <> confcmdargs0 <> aliasargs <> cliargsbeforesep <> cliargsaftersep
           addonargs = dropCliSpecificOpts addonargs0
           shellcmd = printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine addonargs) :: String
         dbgio "addon command selected" cmdname
@@ -561,6 +561,14 @@ checkReqValFlagArgsHaveValues reqvalflagargs = go
       | checkable a, looksLikeKnownFlag b =
           usageError $ a <> " needs a value, but the next argument is another flag: " <> b
       | otherwise = a : go (b:rest)
+
+-- | Split these args at the first "--" argument, dropping it.
+-- That one is the separator hiding later args from hledger's own parsing;
+-- any others belong to whatever we pass the args on to.
+breakAtFirstSeparator :: [String] -> ([String], [String])
+breakAtFirstSeparator as = case break (=="--") as of
+  (bs, _:cs) -> (bs, cs)
+  _          -> (as, [])
 
 -- | Remove any --conf/--no-conf/-n flags, and any --conf value, from these args.
 dropConfFlags :: [String] -> [String]

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -454,13 +454,15 @@ main = handleExit $ withGhcDebug' $ do
     -- The first "--" argument, which sometimes must be used in the command line
     -- to hide addon-specific opts from hledger's cmdargs parsing, is consumed here;
     -- any later "--" arguments are the addon's, and are passed on.
+    -- Anything written after that first "--" is passed on untouched, including
+    -- args which would otherwise look like hledger's own cli-specific options.
     -- Arguments written before the command name, and general opts from the config file,
     -- are not passed since we can't be sure they're supported.
     | isaddoncmd -> do
         let
           (cliargsbeforesep, cliargsaftersep) = breakAtFirstSeparator cliargswithoutcmd
-          addonargs0 = supportedgenargsfromconf <> confcmdargs0 <> aliasargs <> cliargsbeforesep <> cliargsaftersep
-          addonargs = dropCliSpecificOpts addonargs0
+          addonargs0 = supportedgenargsfromconf <> confcmdargs0 <> aliasargs <> cliargsbeforesep
+          addonargs = dropCliSpecificOpts addonargs0 <> cliargsaftersep
           shellcmd = printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine addonargs) :: String
         dbgio "addon command selected" cmdname
         dbgio "addon command arguments" addonargs

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -114,7 +114,8 @@ import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Explicit as CmdArgsWithoutName hiding (Name)
 import System.Environment
 import System.Exit
-import System.Process (system)
+import System.Info (os)
+import System.Process (rawSystem, system)
 import Text.Megaparsec (optional, takeWhile1P, eof)
 import Text.Megaparsec.Char (char)
 import Text.Printf
@@ -463,11 +464,15 @@ main = handleExit $ withGhcDebug' $ do
           (cliargsbeforesep, cliargsaftersep) = breakAtFirstSeparator cliargswithoutcmd
           addonargs0 = supportedgenargsfromconf <> confcmdargs0 <> aliasargs <> cliargsbeforesep
           addonargs = dropCliSpecificOpts addonargs0 <> cliargsaftersep
-          shellcmd = printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine addonargs) :: String
+          addonexe = printf "%s-%s" progname cmdname :: String
+          shellcmd = unwords $ map quoteForCommandLine $ addonexe : addonargs
         dbgio "addon command selected" cmdname
         dbgio "addon command arguments" addonargs
         dbg1IO "running addon" shellcmd
-        system shellcmd >>= exitWith
+        -- Pass the arguments as an argv list, so that they reach the addon exactly as
+        -- written, without shell quoting getting in the way. Except on Windows, where
+        -- we go through the shell, which is what runs .bat and other script addons there.
+        (if os == "mingw32" then system shellcmd else rawSystem addonexe addonargs) >>= exitWith
 
     -- deprecated command found
     -- cmdname == "convert" = error' (modeHelp oldconvertmode)

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -237,6 +237,11 @@ Or you can run them with hledger, like built-in commands: `hledger ui --watch`.
 In this case hledger's config file will be used, so you can set custom options for the addon there.
 (Before hledger 1.50, an `--` argument was needed before addon options, but not any more.)
 
+Arguments written after the command name are passed on to the add-on unchanged,
+except for the options specific to the `hledger` CLI (`--conf`, `--no-conf`, `-n`), which hledger consumes.
+To send one of those to the add-on instead, write it after a `--` argument: `hledger ui -- -n`.
+hledger consumes only that first `--`; later ones are passed on like any other argument.
+
 # Options
 
 Run `hledger -h` to see general command line help.

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -39,6 +39,10 @@ argv: [--sort]
 $  PATH=$PATH:addons hledger argvdump --someunknownflag=x
 argv: [--someunknownflag=x]
 
+# ** 9. Only the first -- is consumed; later ones are the addon's.
+$  PATH=$PATH:addons hledger argvdump -- foo -- bar
+argv: [foo] [--] [bar]
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -71,6 +71,10 @@ argv: [--x] [y]
 $  printf '[argvdump]\n  -- -n\n' >$$.conf; PATH=$PATH:addons hledger --conf $$.conf argvdump; rm -f $$.conf
 argv: [-n]
 
+# ** 17. An argument containing an apostrophe is preserved.
+$  PATH=$PATH:addons hledger argvdump "Sam's Diner"
+argv: [Sam's Diner]
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -51,6 +51,14 @@ argv: [-n]
 $  PATH=$PATH:addons hledger argvdump -n
 argv:
 
+# ** 12. Empty arguments are preserved.
+$  PATH=$PATH:addons hledger argvdump --sort ""
+argv: [--sort] []
+
+# ** 13. Arguments needing shell quoting are preserved.
+$  PATH=$PATH:addons hledger argvdump 'a b' '$x'
+argv: [a b] [$x]
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -43,6 +43,14 @@ argv: [--someunknownflag=x]
 $  PATH=$PATH:addons hledger argvdump -- foo -- bar
 argv: [foo] [--] [bar]
 
+# ** 10. After a --, hledger's own cli-specific options are passed to the addon.
+$  PATH=$PATH:addons hledger argvdump -- -n
+argv: [-n]
+
+# ** 11. Before a --, they are still hledger's.
+$  PATH=$PATH:addons hledger argvdump -n
+argv:
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -27,6 +27,18 @@ $  PATH=$PATH:addons hledger --no-conf addon
 $  PATH=$PATH:addons hledger --conf /dev/null addon
 > /args:$/
 
+# ** 6. A flag of some other command is passed to the addon, not validated by hledger.
+$  PATH=$PATH:addons hledger argvdump --sort
+argv: [--sort]
+
+# ** 7. Likewise when hidden behind a --.
+$  PATH=$PATH:addons hledger argvdump -- --sort
+argv: [--sort]
+
+# ** 8. Unknown addon flags with a joined value still reach the addon.
+$  PATH=$PATH:addons hledger argvdump --someunknownflag=x
+argv: [--someunknownflag=x]
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons.test
+++ b/hledger/test/cli/addons.test
@@ -59,6 +59,18 @@ argv: [--sort] []
 $  PATH=$PATH:addons hledger argvdump 'a b' '$x'
 argv: [a b] [$x]
 
+# ** 14. A "--" written in a config file section is hledger's separator too, and is not passed on.
+$  printf '[argvdump]\n  alpha -- beta\n' >$$.conf; PATH=$PATH:addons hledger --conf $$.conf argvdump gamma; rm -f $$.conf
+argv: [alpha] [beta] [gamma]
+
+# ** 15. A "--" written in a command alias is likewise consumed.
+$  printf '[alias]\n  ad = argvdump -- --x\n' >$$.conf; PATH=$PATH:addons hledger --conf $$.conf ad y; rm -f $$.conf
+argv: [--x] [y]
+
+# ** 16. After that separator, hledger's own cli options reach the addon from a config file too.
+$  printf '[argvdump]\n  -- -n\n' >$$.conf; PATH=$PATH:addons hledger --conf $$.conf argvdump; rm -f $$.conf
+argv: [-n]
+
 
 
 #  ** 0. having no addons shouldn't break the commands list (how to test ?)

--- a/hledger/test/cli/addons/hledger-argvdump
+++ b/hledger/test/cli/addons/hledger-argvdump
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf 'argv:'; for a in "$@"; do printf ' [%s]' "$a"; done; echo

--- a/hledger/test/cli/cli.test
+++ b/hledger/test/cli/cli.test
@@ -276,3 +276,18 @@ $  echo '--alias "unclosed' >$$.conf; hledger --conf $$.conf -f /dev/null files;
 1 \| --alias "unclosed
 this config file line could not be parsed as command line arguments/
 >= 1
+
+# ** 49. The required-value pre-check only considers flags the identified command supports,
+# so another command's flag is left for cmdargs to report.
+$ hledger help --sort
+>2 /Unknown flag: --sort/
+>= 1
+
+# ** 50. The command's own required-value flags are still checked.
+$ hledger register --sort
+>2 /--sort needs a value, none provided/
+>= 1
+
+# ** 51. The pre-check stops at "--", since cmdargs treats what follows as positional args.
+$ printf '' | hledger -f - register -- --sort
+> //


### PR DESCRIPTION
Fixes #2696: pass addon arguments through verbatim, as documented.

As we discussed in chat and in #2696 I split the changes into four commits in the following order:

1. The required-value flag pre-check ran against the union of every subcommand's flags and scanned past `--`, so `hledger foo --sort` and `hledger help --sort` failed with "--sort needs a value". It is now given only the flags relevant to the identified command, and stops at the first `--`.
2. `filter (/="--")` removed every `--` from the addon's arguments. Only the escaping one is consumed now; later ones are passed on.
3. `-n`/`--no-conf`/`--conf VAL` were stripped from the whole addon argument list. They are now stripped only before the first `--`, so `hledger foo -- -n` delivers `-n`. Without a `--` they keep their current meaning as hledger's own options; the manual says so now.
4. Addons are run with `rawSystem` rather than a shell command line, so empty and shell-significant arguments survive.

Tests: A total of 12 new cases in hledger/test/cli/addons.test and cli.test, using a new `hledger-argvdump` dummy addon (as demoed in #2696). All tests passed on my machine for each commit.

Note that commit 4 only fixes the issue on unix-like systems. For Windows we still shell out to cmd, which presumably swallows empty arguments (`""`). I can try to verify this on my Windows machine soon. I'm mostly using a Mac or Linux these days. So no regression on Windows but also presumably no fix. If I can verify that behavior I'll work around that too in a 5th commit.

I also noticed that `hledger run` may be subject to similar bugs regarding empty or shell-significant arguments (like `"'"`). I may file a separate issue if I can confirm that so that heldger and hledger run behave the same when using addons. As I don't use hledger run myself I'm not sure if changing its argument parsing or dispatch might brake existing use cases.

AI usage: written with some help from Claude Opus, from a plan created with Claude Fable. Some finer adjustments in the plan were my doing and I made sure to test and review each commit thoroughly. Usage in output token is denoted on each commit. btw: I chose to keep with the existing pattern of only documenting use of one model per commit, which is why the plan's AI usage is included in the first commit and the implementation is divvied up among the rest.