### PR TITLE
fix:web: escape add-form error messages

### DIFF
--- a/hledger-web/Hledger/Web/Handler/AddR.hs
+++ b/hledger-web/Hledger/Web/Handler/AddR.hs
@@ -11,6 +11,7 @@ module Hledger.Web.Handler.AddR
   ) where
 
 import Data.Aeson.Types (Result(..))
+import Data.List (intersperse)
 import Data.Text qualified as T
 import Network.HTTP.Types.Status (status400)
 import Text.Blaze.Html (preEscapedToHtml)
@@ -44,7 +45,11 @@ postAddR = do
       redirect JournalR
     FormMissing -> showForm view enctype
     FormFailure errs -> do
-      mapM_ (setMessage . preEscapedToHtml . T.replace "\n" "<br>") errs
+      -- Escape each error, then join the lines with <br>. An unbalanced
+      -- transaction's error embeds an excerpt of the submitted entry (account
+      -- names, amounts), so it must be escaped; only the <br> we insert is
+      -- raw. (Cf EditR, which uses toHtml.)
+      mapM_ (setMessage . mconcat . intersperse (preEscapedToHtml ("<br>" :: T.Text)) . map toHtml . T.lines) errs
       showForm view enctype
   where
     showForm view enctype =

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -145,6 +145,34 @@ hledgerWebTest = do
       bodyContains "id=\"transaction-2-1\""
       bodyContains "id=\"transaction-2-2\""
 
+  -- Submitting an unbalanced transaction produces an error message that
+  -- echoes the entry (account names, amounts). Those values must be rendered
+  -- as text, not raw html.
+  aj <- fmap (either error' id) . runExceptT . journalFinalise iopts "add.journal" "" =<<
+          readJournal'' (T.pack $ unlines  -- PARTIAL: readJournal'' should not fail
+            ["2025-01-01 opening"
+            ,"    assets:bank:checking   100"
+            ,"    equity:opening"])
+  runTests "hledger-web add form" [("allow","add")] aj $ do
+
+    yit "escapes submitted values in an add-form error message" $ do
+      get JournalR
+      statusIs 200
+      -- an account name that parses but leaves the transaction unbalanced
+      request $ do
+        setMethod "POST"
+        setUrl AddR
+        addToken  -- from the add form on the page just fetched
+        addPostParam "_formid" "identify-add"
+        addPostParam "date" "2025-02-02"
+        addPostParam "description" "xsstest"
+        addPostParam "account" "x<img src=x onerror=alert(1)>"
+        addPostParam "amount" "5"
+        addPostParam "account" "equity:opening"
+        addPostParam "amount" "-3"
+      bodyContains "&lt;img src=x onerror"       -- the value, escaped
+      bodyNotContains "<img src=x onerror"       -- and never as raw html
+
   -- #2127
   -- XXX I'm pretty sure this test lies, ie does not match production behaviour.
   -- (test with curl -s http://localhost:5000/journal | rg '(href)="[\w/].*?"' -o )


### PR DESCRIPTION
add-form FormFailure message was rendered with preEscapedToHtml, ie raw html. When a submitted transaction parses but does not balance, that message includes an excerpt of the entry - the account names and amounts submitted - so a payload in an account name (eg `x<img src=x onerror=...>`) ran when the message was shown.

The user would have to submit the payload themselves since the CSRF token stops another site submitting on their behalf. But the value can reach the account field via autocomplete from imported journal data, so it is worth closing.

The fix escapes each error line and joins with `<br>`, so only the `<br>` we insert is raw. EditR already renders its messages with toHtml; this brings AddR in line.

Server-testable. The yesod-test submits an unbalanced transaction with a payload account name and checks that the response escapes it. Runs in the normal stack test / CI; reverting the fix makes it fail.

AI usage: Claude Opus 4.8, ~15k output tokens
