### PR TITLE
doc: fix the install command in generated release notes

### DIFF
--- a/doc/ghrelnotes
+++ b/doc/ghrelnotes
@@ -50,7 +50,7 @@ Updates to binaries:
 
 If you have [eget](https://github.com/zyedidia/eget), that's a convenient way to download the right binaries for your machine:
 ```
-eget simonmichael/hledger --all --pre-release
+eget plaintextaccounting/hledger --all --pre-release
 ```
 
 <!--

--- a/doc/ghrelnotes
+++ b/doc/ghrelnotes
@@ -78,7 +78,7 @@ Otherwise:
 At the command line:
 
 ```
-curl -fLOC- https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-linux-x64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
+curl -fL https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-linux-x64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
 hledger --version; hledger-ui --version; hledger-web --version    # should show $REL
 ```
 
@@ -99,13 +99,13 @@ and/or [Homebrew](https://brew.sh), and let me know.)
 
 On ARM macs:
 ```
-curl -fLOC- https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-mac-arm64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
+curl -fL https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-mac-arm64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
 hledger --version; hledger-ui --version; hledger-web --version    # should show $REL
 ```
 
 On Intel macs:
 ```
-curl -fLOC- https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-mac-x64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
+curl -fL https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-mac-x64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
 hledger --version; hledger-ui --version; hledger-web --version    # should show $REL
 ```
 

--- a/doc/ghrelnotes
+++ b/doc/ghrelnotes
@@ -77,6 +77,9 @@ Otherwise:
 
 At the command line:
 
+- `/usr/local/bin` is in `$PATH` by default on most distributions; to install elsewhere, change `tar`'s `-C` argument.
+- Prefix `tar` with `sudo` if `/usr/local/bin` is not writable.
+
 ```
 curl -fL https://github.com/plaintextaccounting/hledger/releases/download/$REL/hledger-linux-x64.tar.gz | tar -xzv -f- -C/usr/local/bin hledger hledger-ui hledger-web
 hledger --version; hledger-ui --version; hledger-web --version    # should show $REL
@@ -90,10 +93,20 @@ hledger --version; hledger-ui --version; hledger-web --version    # should show 
 
 </summary>
 
+If you have homebrew:
+```
+brew install hledger
+```
+
+Otherwise...
+
 In a terminal window (don't download the binaries with your web browser, they won't get authorised):
+
+- `/usr/local/bin` is in `$PATH` by default on macOS; to install elsewhere, change `tar`'s `-C` argument.
+- Prefix `tar` with `sudo` if `/usr/local/bin` is not writable.
 <!--
-(Hopefully these commands are all installed by default; 
-if not, install [XCode Command Line Tools](https://mac.install.guide/commandlinetools/) 
+(Hopefully these commands are all installed by default;
+if not, install [XCode Command Line Tools](https://mac.install.guide/commandlinetools/)
 and/or [Homebrew](https://brew.sh), and let me know.)
 -->
 


### PR DESCRIPTION
Fixes #2707 

The install command on every release page since 1.42 downloads the tarball
and then throws it away:

```
curl -fLOC- .../hledger-linux-x64.tar.gz | tar -xzv -f- -C/usr/local/bin ...
```

`-O` tells curl to write the body to a file, so the pipe gets nothing and
tar fails on empty input. The user ends up with no binaries installed and an
unexpected tarball in whatever directory they were in. `-C-` (resume) also
only makes sense when writing to a file.

Both flags are correct in `doc/ghtestbinnotes.md`, where the download and the
extraction are two separate commands. They appear to have been carried over
when those were joined into one pipe.

Three commits:

1. drop `-O` and `-C-`, the fix for #2707
2. note that `/usr/local/bin` usually needs `sudo` and that the destination can
   be changed; offer `brew install hledger` first on mac
3. update the `eget` repo path to `plaintextaccounting/hledger`

2 and 3 are separable if you would rather take only the fix.

### Checked

Against 1.52.3 on mac arm64, extracting to a temp directory:

- current command: 0 bytes reach tar, nothing extracted
- fixed command: `hledger`, `hledger-ui`, `hledger-web` all extracted, and
  `hledger --version` reports `1.52.3-g3eeb3bc43-20260827, mac-aarch64`
- `/usr/local/bin` on this machine is `root:wheel drwxr-xr-x`, so even the
  fixed command needs `sudo` there — hence commit 2

### Rendered

Generated with `doc/ghrelnotes 1.52.3` and rendered through GitHub's markdown
API, sections expanded:

<!-- drop relnotes-install.png here -->
<img width="1800" height="3730" alt="relnotes-edited" src="https://github.com/user-attachments/assets/3b7187f6-4777-418d-9687-55d27b8ca1f6" />

### Not covered

- The ~23 published releases from 1.42 to 1.52.3 still carry the old command
  in their notes; this only affects releases generated from now on.
- hledger.org is not affected — `get-hledger-installed.md` uses `curl -sL`,
  which works. It is pinned to 1.50 though, which is a separate matter for
  the site repo.

### Note
I think this is ready to go, but it's marked as draft due to repo open pr limit

AI usage: Claude opus 5, ~17k Tokens - listed individually in the commits too.
