### PR TITLE
ci: run the addon functional tests

### DIFF
--- a/.github/workflows/_binaries-windows-arm64.yml
+++ b/.github/workflows/_binaries-windows-arm64.yml
@@ -114,9 +114,9 @@ jobs:
     # - if [[ ! -x ~/.local/bin/shelltest ]]; then stack install shelltestrunner-1.11; fi
     # - shelltest --version
 
-    # run hledger-lib/hledger functional tests, skipping the ones for addons
+    # run hledger-lib/hledger functional tests
     ## - export PATH=~/.local/bin:$PATH
-    #- COLUMNS=80 stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
+    #- COLUMNS=80 stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
 
     # artifacts:
 

--- a/.github/workflows/binaries-mac-arm64-hx.yml
+++ b/.github/workflows/binaries-mac-arm64-hx.yml
@@ -140,9 +140,9 @@ jobs:
         command -v shelltest >/dev/null || brew install shelltestrunner
         shelltest --version
 
-    - name: Test functional tests (excluding addons)
+    - name: Test functional tests
       run: |
-        COLUMNS=80 shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
+        COLUMNS=80 shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
 
     # - name: Test haddock generation
     #   run: |

--- a/.github/workflows/binaries-mac-arm64.yml
+++ b/.github/workflows/binaries-mac-arm64.yml
@@ -127,10 +127,10 @@ jobs:
         if [[ ! -x ~/.local/bin/shelltest ]]; then $stack install --verbosity=error shelltestrunner-1.11; fi
         shelltest --version
 
-    - name: Test functional tests (excluding addons)
+    - name: Test functional tests
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected # bin
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected # bin
 
     # This is tested here rather than in the regular CI because it's slow,
     # doesn't fail too often, and the cost of late detection and fixing is low.

--- a/.github/workflows/binaries-mac-x64.yml
+++ b/.github/workflows/binaries-mac-x64.yml
@@ -129,10 +129,10 @@ jobs:
         if [[ ! -x ~/.local/bin/shelltest ]]; then $stack install --verbosity=error shelltestrunner-1.11; fi
         shelltest --version
 
-    - name: Test functional tests (excluding addons)
+    - name: Test functional tests
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected # bin
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected # bin
 
     # artifacts:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,10 +334,10 @@ jobs:
       if: env.do-all
 
     # Takes ~30s on a 2023 github worker.
-    - name: Test functional tests (excluding addons)
+    - name: Test functional tests
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
         # XXX run the bin/ func tests corresponding to the GHC version enabled above, only
       if: env.do-all
 

--- a/.github/workflows/oldest.yml
+++ b/.github/workflows/oldest.yml
@@ -147,8 +147,8 @@ jobs:
     #     if [[ ! -x ~/.local/bin/shelltest ]]; then $stack install --verbosity=error shelltestrunner-1.11; fi
     #     shelltest --version
 
-    # - name: Test functional tests (excluding addons)
+    # - name: Test functional tests
     #   run: |
     #     export PATH=~/.local/bin:$PATH
-    #     COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
+    #     COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x ledger-compat/ledger-baseline -x ledger-compat/ledger-regress -x ledger-compat/ledger-collected
     #     # XXX run the bin/ func tests corresponding to the GHC version enabled above, only


### PR DESCRIPTION
`-x /addons` is vestigial. The condition it worked around was removed in 509e5747c.

### History

`hledger/test/cli/addons/` held generated, gitignored scripts from 2014 to 2026. CI excluded
`addons.test` from 1afe5fba6 (2017-03-30), and the flag was copied into every shelltest step
written since. 509e5747c (2026-02-18) committed real scripts but did not remove the exclusion, so
the tests run under `functest` and have not run in CI since.

### Verification

Same commit, same command, exclusion on and off:

| | test cases | failed |
|---|---|---|
| `-x /addons` (current CI) | 1720 | 0 |
| without it (this PR) | 1725 | 0 |

The delta is the five cases in `addons.test`, so they ran rather than being skipped silently.

- linux, ubuntu-24.04, this workflow: https://github.com/acinader/hledger/actions/runs/33278322681
- mac arm64, shelltest 1.11 from brew: same counts

### Also

- Drops "(excluding addons)" from the step names, and the matching "skipping the ones for addons"
  comment in `_binaries-windows-arm64.yml`.
- The commented-out shelltest line in `_binaries-windows-arm64.yml` is updated for consistency.

### Relevance

#2699 adds 10 cases to `addons.test` and 3 to `cli.test`. Under the current exclusion most of
that PR's coverage would not run in CI.

This PR is mergeable but marked draft to comply with open PR policy.

AI usage: Claude Opus 5, ~10k output tokens
