### PR TITLE
fix: quote empty arguments and escape apostrophes when building a shell command line

### DIFF
--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -180,6 +180,8 @@ shellQuoteIfNeeded
 -- "'\"'"
 -- >>> quoteForCommandLine "$"
 -- "'$'"
+-- >>> quoteForCommandLine "it's"
+-- "'it'\\''s'"
 --
 quoteForCommandLine :: String -> String
 quoteForCommandLine s
@@ -187,11 +189,13 @@ quoteForCommandLine s
   | any (`elem` s) (quotechars++whitespacechars++shellchars) = singleQuote $ escapeSingleQuotes s
   | otherwise = s
 
--- | Escape single quotes appearing in a string we're protecting by wrapping in single quotes
+-- | Escape single quotes appearing in a string we're protecting by wrapping in single quotes.
+-- A backslash is not an escape inside single quotes in POSIX sh, so the quote has to be
+-- closed, the apostrophe emitted separately, and the quote reopened: 'it'\\''s'.
 escapeSingleQuotes :: String -> String
 escapeSingleQuotes = concatMap escapeSingleQuote
   where
-    escapeSingleQuote c | c `elem` "'" = ['\\',c]
+    escapeSingleQuote c | c `elem` "'" = "'\\''"
     escapeSingleQuote c = [c]
 
 quotechars, whitespacechars, redirectchars, shellchars :: [Char]

--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -183,6 +183,7 @@ shellQuoteIfNeeded
 --
 quoteForCommandLine :: String -> String
 quoteForCommandLine s
+  | null s = "''"  -- an empty argument must be quoted, or it vanishes from the command line
   | any (`elem` s) (quotechars++whitespacechars++shellchars) = singleQuote $ escapeSingleQuotes s
   | otherwise = s
 

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -377,3 +377,9 @@ one
 # ** 31. run passes an empty argument to an addon, as the command line does.
 $ mkdir -p $$d; printf '#!/bin/sh\nprintf "argv:"; for a in "$@"; do printf " [%%s]" "$a"; done; echo\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; printf 'zzzz a "" b\n' >$$f; PATH=$$d:$PATH hledger run -f /dev/null $$f; rm -rf $$d $$f
 argv: [-f] [/dev/null] [a] [] [b]
+
+# ** 32. repl passes an empty argument to an addon, as the command line does.
+<
+zzzz a "" b
+$ sh -c 'D=$(mktemp -d "${TMPDIR:-/tmp}/hledger-addon.XXXXXX"); J=$(mktemp "${TMPDIR:-/tmp}/hledger-addonj.XXXXXX"); printf "#!/bin/sh\nprintf argv:; for a in \"\$@\"; do printf \" [%%s]\" \"\$a\"; done; echo\n" > "$D/hledger-zzzz"; chmod +x "$D/hledger-zzzz"; printf "2017-01-01 x\n  a  1\n  b\n" > "$J"; PATH="$D:$PATH" hledger repl --no-conf -f "$J"; rm -rf "$D" "$J"'
+> /argv: \[-f\] \[.*\] \[a\] \[\] \[b\]/

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -373,3 +373,7 @@ after
 $ mkdir -p $$d; printf '#!/bin/sh\nexit 3\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; PATH=$$d:$PATH hledger run -f /dev/null -- echo one -- zzzz -- echo two; s=$?; rm -rf $$d; exit $s
 one
 >= 3
+
+# ** 31. run passes an empty argument to an addon, as the command line does.
+$ mkdir -p $$d; printf '#!/bin/sh\nprintf "argv:"; for a in "$@"; do printf " [%%s]" "$a"; done; echo\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; printf 'zzzz a "" b\n' >$$f; PATH=$$d:$PATH hledger run -f /dev/null $$f; rm -rf $$d $$f
+argv: [-f] [/dev/null] [a] [] [b]

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -383,3 +383,7 @@ argv: [-f] [/dev/null] [a] [] [b]
 zzzz a "" b
 $ sh -c 'D=$(mktemp -d "${TMPDIR:-/tmp}/hledger-addon.XXXXXX"); J=$(mktemp "${TMPDIR:-/tmp}/hledger-addonj.XXXXXX"); printf "#!/bin/sh\nprintf argv:; for a in \"\$@\"; do printf \" [%%s]\" \"\$a\"; done; echo\n" > "$D/hledger-zzzz"; chmod +x "$D/hledger-zzzz"; printf "2017-01-01 x\n  a  1\n  b\n" > "$J"; PATH="$D:$PATH" hledger repl --no-conf -f "$J"; rm -rf "$D" "$J"'
 > /argv: \[-f\] \[.*\] \[a\] \[\] \[b\]/
+
+# ** 33. run passes an argument containing an apostrophe to an addon unchanged.
+$ mkdir -p $$d; printf '#!/bin/sh\nprintf "argv:"; for a in "$@"; do printf " [%%s]" "$a"; done; echo\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; printf 'zzzz a "it%ss" b\n' "'" >$$f; PATH=$$d:$PATH hledger run -f /dev/null $$f; rm -rf $$d $$f
+argv: [-f] [/dev/null] [a] [it's] [b]


### PR DESCRIPTION
`quoteForCommandLine` has two defects, both of which lose or mangle an argument on
its way to a shell command line.

**Empty arguments vanish.** It returns a string unchanged when it contains no
quote, whitespace or shell character. An empty string contains none, so it comes
back unquoted and `unwords` drops it:

    unwords (map quoteForCommandLine ["a", "", "b"])  ==  "a  b"

**Apostrophes break the quoting.** When an argument does need quoting it is
wrapped in single quotes, and `escapeSingleQuotes` escaped an embedded apostrophe
as `\'`. A backslash is not an escape inside single quotes in POSIX sh, so the
quote closes at the apostrophe and the line no longer parses:

    argument   it's

    before     sent to sh as  'it\'s'    -> unterminated quote, sh rejects the line
    after      sent to sh as  'it'\''s'  -> addon receives [it's]

Both are fixed in `quoteForCommandLine` itself: an empty string becomes `''`, and
an apostrophe uses the POSIX idiom of closing the quote, emitting it, and
reopening.

### What this affects

Every caller that builds a shell command line rather than passing an argv list:
`Run.hs` for addons under `run` and `repl`, and the `!` shell alias path in
`Cli.hs`.

```
$ cat cmds.txt
zzzz a "" b

before   hledger run -f /dev/null cmds.txt    argv: [-f] [/dev/null] [a] [b]
after                                         argv: [-f] [/dev/null] [a] [] [b]
```

An apostrophe in a payee or description is common enough to hit in ordinary use —
`hledger ui "Trader Joe's"` fails on main.

### Windows

This does not close the Windows gap. `quoteForCommandLine` has no platform branch,
and cmd.exe does not recognise single quotes as a quoting character —
`shellQuoteIfNeeded`'s docstring says exactly that, and uses double-quote escaping
there instead. So on Windows `''` would arrive as two literal characters rather
than an empty argument. Closing that would mean making `quoteForCommandLine`
platform-aware.

I have a CI probe showing empty arguments survive on Windows when quoted as `""`,
but that is a different form from what this PR emits, so I am not claiming the
Windows half is fixed. I'll confirm the actual behaviour separately.

### Tests

`run.test` 31 covers an empty argument through `run`, 32 through `repl`, and 33 an
argument containing an apostrophe. A doctest covers `quoteForCommandLine` directly.
All fail on main and pass with the fix.

Full functional suite 1735/1735, doctests 297/297, builds warning-free under `-Werror`.

### Provenance

Found while testing #2699, but independent of it: the defect is in `hledger-lib`
and predates that PR. It stands on its own against main and can land in any order.

The apostrophe half was also reached independently in the review session linked
from #2699 (finding 5), which suggested fixing both in `quoteForCommandLine`
together rather than special-casing them at the call sites — which is what this
now does.

Ready for merge but marked draft to comply with pr policy.

AI usage: Claude Opus 5, ~15k output tokens
