### PR TITLE
;dev:web: don't let the add-form tests depend on post param order

### DIFF
--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -268,6 +268,9 @@ hledgerWebTest = do
     -- in the CSRF token, so that the two failures can only be about the token.
     -- The form is wrapped in identifyForm, so _formid must be sent too, or the
     -- post is ignored as FormMissing and these would pass either way.
+    -- Both postings send an explicit amount: the form pairs the account and
+    -- amount params by position, and yesod-test before 1.7.0 sends repeated
+    -- params in reverse order, which would leave an account without its amount.
     let postTransaction desc = do
           setMethod "POST"
           setUrl AddR
@@ -277,7 +280,7 @@ hledgerWebTest = do
           addPostParam "account" "assets:bank:checking"
           addPostParam "amount" "1"
           addPostParam "account" "income:gifts"
-          addPostParam "amount" ""
+          addPostParam "amount" "-1"
 
     yit "does not add a transaction when the CSRF token is missing" $ do
       request $ postTransaction "CsrfNoToken"


### PR DESCRIPTION
Reported by @hseg in #2700: two write tests fail on stack98.yaml.

yesod-test before 1.7.0 renders post params in reverse addition order (fixed by
yesodweb/yesod#1867). The add form pairs the repeated `account`/`amount` params by
position, so on those snapshots the second posting's blank amount arrives first and leaves
an account with no amount. The post fails validation, and "adds a transaction when the CSRF
token is present" and "does not let the add form write a newline into the journal" fail.

Sending an explicit amount for both postings makes the pairing correct in either order.
hledger-web itself is unaffected — a browser sends form fields in document order.

Affected: stack96.yaml (yesod-test 1.6.16), stack98.yaml (1.6.16), stack910.yaml (1.6.19).
Fine on stack.yaml (1.7.0.2) and stack912.yaml (1.7.0.1), which is why ci.yml is green.
oldest.yml (stack96.yaml) runs the suites too, but its head is 36740f0c9, before these
tests landed — so it would go red as it stands.

Verified with `stack test hledger-web`, and by posting the params
in reverse order on the current stack.yaml to simulate the older yesod-test — that
reproduces the reported failure, and passes with this change.

AI usage: Claude Opus 5, ~25k output tokens
