### PR TITLE
imp:web: tidy up the presentation of tabular data and other css fixes

### DIFF
--- a/hledger-web/STYLE.md
+++ b/hledger-web/STYLE.md
@@ -1,0 +1,77 @@
+# hledger-web style notes
+
+The rules a change to the web UI's appearance is expected to follow, by
+whoever makes it - person or coding agent. They are written down so that each
+change does not have to re-derive them from the existing css.
+
+Discussion of the overall direction is in
+[#200](https://github.com/plaintextaccounting/hledger/issues/200).
+
+## Constraints
+
+- **No build step.** hledger-web builds with stack alone. Css and js are
+  vendored under `static/` and served as-is; there is no preprocessor, bundler,
+  or npm step in the build. A change that needs one is out of scope.
+- **Nothing loads from a third party.** No CDNs, no web fonts fetched at
+  runtime. Everything ships with the binary.
+- **Server-rendered and static-first.** Pages are Hamlet templates; javascript
+  is for the few things that genuinely need it. See `static/hledger.js`.
+
+## Where style lives
+
+- `static/hledger.css` is the only stylesheet we own. It is grouped into
+  numbered sections; add to the section that fits rather than appending.
+- **No `style=` attributes in templates.** Alignment, spacing and color belong
+  in css, keyed off a class. The templates carry semantic classes
+  (`.date`, `.description`, `.account`, `.amount`) — use those.
+- Bootstrap 3 is still vendored and supplies the grid, forms, buttons and the
+  offcanvas sidebar. Our stylesheet loads after it, so plain overrides work; no
+  `!important` needed, and it should be treated as a smell.
+
+## Tabular and monetary data
+
+The journal, register and sidebar are tables of figures, and read like a ledger.
+
+- **Amounts get tabular figures.** `font-feature-settings:"tnum"` plus
+  `font-variant: tabular-nums`, so digits are the same width and stack
+  place-by-place down the column. Right alignment already lines up the decimal
+  points, so the effect is subtle; it is the right default for money either
+  way. Applied to `.amount`, which `mixedAmountAsHtml` puts on both the cell
+  and the amount spans inside it.
+- **Amounts are right-aligned**, so decimal points line up. Text columns are
+  left-aligned. Both come from css, not per-cell attributes.
+- **Column headers label the data, they are not part of it**: small, uppercase,
+  letter-spaced and muted, not bold black.
+- **Rows are separated by one hairline**, with no zebra striping and no vertical
+  rules. A row lights up faintly on hover to help the viewer when
+  reading a wide row across to its amount.
+- **Color carries meaning, never decoration.** Negative amounts are red
+  (`.negative`); the rest of the table is near-monochrome.
+- **Do not assume `.` is the decimal mark.** Amounts are formatted server-side
+  by hledger and vary by journal and locale, so alignment must not depend on the
+  separator.
+
+## Reviewing an appearance change
+
+Screenshots, before and after, of a journal with enough data to fill the page.
+The browser tests (`test/browser`) can check that markup and behavior survive,
+but they cannot judge how it looks.
+
+## Known gaps
+
+Deliberately not addressed yet, in rough order of appeal:
+
+- **Bootstrap 3 itself.** It is the last large vendored asset besides jquery and
+  flot, and it pulls in glyphicons (7 in use, ~148KB of fonts). Bootstrap 4
+  dropped glyphicons, so any upgrade is also an icon migration. Replacing it
+  with plain modern css — the app has one layout — would remove more than it
+  adds, but it is a project of its own.
+- **`sidebarToggle` in `hledger.js`** spells out the responsive grid classes
+  three times. It should move to css, or to one helper, whenever the grid is
+  touched.
+- **`.transactionsreport .posting td { border: none !important }`** fights any
+  row-border work and should be reworked rather than layered on.
+- **Charts.** flot is dated and needs jquery. Rethinking them is likely part of
+  hledger 2.0, not a css change.
+- **A strict Content-Security-Policy**: #2703. It also decides whether
+  `style-src` can be strict, which depends on the remaining `style=` attributes.

--- a/hledger-web/STYLE.md
+++ b/hledger-web/STYLE.md
@@ -73,5 +73,6 @@ Deliberately not addressed yet, in rough order of appeal:
   row-border work and should be reworked rather than layered on.
 - **Charts.** flot is dated and needs jquery. Rethinking them is likely part of
   hledger 2.0, not a css change.
-- **A strict Content-Security-Policy**: #2703. It also decides whether
-  `style-src` can be strict, which depends on the remaining `style=` attributes.
+- **A strict Content-Security-Policy**: #2703. The templates no longer carry
+  `style=` attributes, so `style-src` can be strict too, once flot's legend,
+  which it builds from inline styles, is dealt with.

--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -56,8 +56,15 @@ body {
 }
 
 /* A date is one token; don't break it across lines. */
-.date {
+td.date {
   white-space: nowrap;
+}
+
+/* One row, one line: descriptions arrive elided, so the width is bounded. */
+@media (min-width: 992px) { /* under md: no room */
+  td.description {
+    white-space: nowrap;
+  }
 }
 
 /* A row lights up under the pointer, which helps when reading a wide row

--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -1,4 +1,9 @@
-/* hledger web ui styles */
+/* hledger web ui styles
+ *
+ * Conventions and the reasoning behind them: ../STYLE.md
+ * Short version: no build step, nothing from a third party, style lives here
+ * rather than in style= attributes, and amounts get tabular figures.
+ */
 
 /*------------------------------------------------------------------------------------------*/
 /* 0. revert some things */
@@ -36,6 +41,43 @@
 /* 2. fonts */
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+/*------------------------------------------------------------------------------------------*/
+/* 3. tabular data: amounts, dates, column headers */
+
+/* Amounts read as a column of figures: tabular (fixed width) digits, aligned
+   right so the decimal points line up. Both the cell and the amount spans
+   inside it carry .amount, so this reaches either. */
+.amount {
+  font-feature-settings: "tnum";
+  font-variant: tabular-nums;
+  text-align: right;
+}
+
+/* A date is one token; don't break it across lines. */
+.date {
+  white-space: nowrap;
+}
+
+/* A row lights up under the pointer, which helps when reading a wide row
+   across to its amount. The :target rule further down overrides this. */
+.table > tbody > tr:hover > td {
+  background-color: #f6f8fa;
+}
+
+/* Column headers label the data, they are not part of it: small, spaced and
+   muted. Left alignment comes from bootstrap's th rule; .amount above
+   overrides it for the figure columns. */
+.table > thead > tr > th,
+.table > thead > th {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #687385;
+  border-bottom: 1px solid #e6e8eb;
+  white-space: normal;
 }
 
 /*------------------------------------------------------------------------------------------*/
@@ -204,10 +246,6 @@ ul {
 
 .negative {
     color: #a94442;
-}
-
-.date {
-    whitespace: nowrap;
 }
 
 .col-any-0 {

--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -88,8 +88,25 @@ td.date {
 }
 
 /*------------------------------------------------------------------------------------------*/
-/* 4. the add form's date picker button */
+/* 4. the add form */
 
+/* Each posting row is indented a little under the date and description. */
+#addform .account-group {
+  padding-left: 1em;
+}
+
+/* When the journal has several files, a selector chooses which one to add to.
+   It sits inline after its "Add to:" label instead of filling the row. */
+#addform .file-select {
+  display: inline-block;
+  width: auto;
+}
+
+#addform button[type=submit] {
+  font-weight: bold;
+}
+
+/* The date picker button. */
 #datebutton {
   cursor: pointer;
 }
@@ -152,6 +169,40 @@ dialog::backdrop {
    something the user tabs to, so it does not need a focus ring. */
 dialog:focus {
   outline: none;
+}
+
+/* In the help dialog's lists, an item that starts a new group. */
+.modal-body li.gap-above {
+  margin-top: 1em;
+}
+
+/*------------------------------------------------------------------------------------------*/
+/* 7. the register chart */
+
+/* flot draws into this, and needs it to have a size first. */
+#register-chart {
+  height: 150px;
+  margin-bottom: 1em;
+}
+
+/*------------------------------------------------------------------------------------------*/
+/* 8. the manage, edit and upload pages */
+
+/* The list of journal files: each name is centered against its row of buttons. */
+.table.files td.filename {
+  vertical-align: middle;
+}
+
+/* The edit form is a table only for layout; no rules between its cells. */
+.table.edit-form td {
+  border: 0;
+}
+
+/* The upload form's file input is hidden; its label, styled as a button, is
+   the visible control and opens the file dialog. (Bootstrap makes file inputs
+   display:block, which outranks the hidden attribute, hence a rule here.) */
+label.btn > input[type=file] {
+  display: none;
 }
 
 ul {

--- a/hledger-web/templates/add-form.hamlet
+++ b/hledger-web/templates/add-form.hamlet
@@ -20,7 +20,7 @@
 
 <div .account-postings>
   $forall (n, (acc, amt, accE, amtE)) <- displayRows
-    <div .form-group .row .account-group style="padding-left:1em;">
+    <div .form-group .row .account-group>
       <div .col-sm-9.col-xs-9 :isJust accE:.has-error>
         <input .account-input.form-control.input-lg type=text list=accountnames
           name=account placeholder="Account #{n}" value="#{acc}">
@@ -37,12 +37,12 @@
     $if length files > 1
       Add to:
       &nbsp;
-      <div style="display:inline-block; width:auto;" .form-group :isJust (fvErrors fileView):.has-error>
+      <div .form-group .file-select :isJust (fvErrors fileView):.has-error>
         ^{fvInput fileView}
         $maybe err <- fvErrors fileView
           <span .help-block .error-block>#{err}
-  <div .col-sm-3.col-xs-3 style="text-align:right;">
-    <button type=submit .btn .btn-default .btn-lg name=submit style="font-weight:bold;">Save
+  <div .col-sm-3.col-xs-3.text-right>
+    <button type=submit .btn .btn-default .btn-lg name=submit>Save
 
 $# Completion data for the account and description fields. The browser filters
 $# these itself, so there is no javascript and no library involved, and hamlet's

--- a/hledger-web/templates/chart.hamlet
+++ b/hledger-web/templates/chart.hamlet
@@ -1,6 +1,6 @@
 $# If $ is the first character in a line, it must be \-escaped to hide it from hamlet.
-<label #register-chart-label style=""><br>
-<div #register-chart style="height:150px; margin-bottom:1em; display:block;">
+<label #register-chart-label><br>
+<div #register-chart>
 <script type=text/javascript>
   \$(document).ready(function() {
     var $chartdiv = $('#register-chart');

--- a/hledger-web/templates/default-layout.hamlet
+++ b/hledger-web/templates/default-layout.hamlet
@@ -109,5 +109,5 @@ $if elem ViewPermission perms
                 <li> <code>expr:'QEXPR'</code> - match with a boolean query (and, or, not, (..))
                 <li>  <code>any:'QEXPR'</code> - match transactions where any posting matches
                 <li>  <code>all:'QEXPR'</code> - match transactions where all postings match
-                <li style="margin-top:1em;"> <code>depth:N</code> - clip account names at this depth
+                <li .gap-above> <code>depth:N</code> - clip account names at this depth
                 $# <li> Description, account, status query terms are OR'ed, others are AND'ed.

--- a/hledger-web/templates/edit-form.hamlet
+++ b/hledger-web/templates/edit-form.hamlet
@@ -4,14 +4,14 @@
   <i>#{f}
 <div.alert.alert-danger>
   Are you sure? This will overwrite your journal!
-<table.table.table-condensed>
+<table.table.table-condensed.edit-form>
   <tr>
-    <td colspan=2 style="border:0">
+    <td colspan=2>
       ^{fvInput tView}
   <tr>
-    <td style="border:0">
+    <td>
       <span.help>
         ^{helplink "data-formats" "File format help"}
-    <td .text-right style="border:0">
+    <td .text-right>
       <a.btn.btn-default href="@{ManageR}">Go back
       <input.btn.btn-default type=submit value="Save">

--- a/hledger-web/templates/journal.hamlet
+++ b/hledger-web/templates/journal.hamlet
@@ -9,10 +9,10 @@ $if elem AddPermission perms
 <div .table-responsive>
   <table .transactionsreport .table .table-condensed>
     <thead>
-      <th .date style="text-align:left;">Date
-      <th .description style="text-align:left;">Description
-      <th .account style="text-align:left;">Account
-      <th .amount style="text-align:right;">Amount
+      <th .date>Date
+      <th .description>Description
+      <th .account>Account
+      <th .amount>Amount
 
     $forall torig <- items
       <tr .title ##{transactionFrag torig} title="#{showTransaction torig}">
@@ -20,7 +20,7 @@ $if elem AddPermission perms
           #{show (tdate torig)}
         <td colspan=2>
           #{textElideRight 60 (tdescription torig)}
-        <td .amount style="text-align:right;">
+        <td .amount>
 
       $forall Posting { paccount = acc, pamount = amt } <- tpostings torig
         <tr .posting>
@@ -30,7 +30,7 @@ $if elem AddPermission perms
             &nbsp;
             <a href="@?{acctlink acc}##{tindex torig}" title="#{acc}">
               #{elideAccountName 40 acc}
-          <td .amount style="text-align:right;">
+          <td .amount>
             ^{mixedAmountAsHtml amt}
 
 $if elem AddPermission perms

--- a/hledger-web/templates/journal.hamlet
+++ b/hledger-web/templates/journal.hamlet
@@ -2,7 +2,7 @@
   #{title'}
 
 $if elem AddPermission perms
-  <a #addformlink href="#" role="button" style="cursor:pointer; margin-top:1em;"
+  <a #addformlink href="#" role="button"
      data-toggle="modal" data-target="#addmodal" title="Add a new transaction to the journal">
     Add a transaction
 

--- a/hledger-web/templates/manage.hamlet
+++ b/hledger-web/templates/manage.hamlet
@@ -3,7 +3,7 @@
 
 <div.row>
   <div .col-md-6.col-sm-8.col-xs-12>
-    <table .table.table-condensed>
+    <table .table.table-condensed.files>
       <thead>
         <th>
           File
@@ -11,9 +11,9 @@
       <tbody>
         $forall (path, _) <- jfiles j
           <tr>
-            <td style="vertical-align:middle">
+            <td .filename>
               #{path}
-            <td style="text-align:right">
+            <td .text-right>
               <a.btn.btn-default href=@{EditR path}>
                 Edit
               <a.btn.btn-default href=@{UploadR path}>

--- a/hledger-web/templates/register.hamlet
+++ b/hledger-web/templates/register.hamlet
@@ -23,7 +23,7 @@
           <td .date nowrap>
             <a href="@?{(JournalR, [("q", T.unwords $ removeInacct qparam)])}##{transactionFrag torig}">
               #{show (tdate tacct)}
-          <td>
+          <td .description>
             #{textElideRight 30 (tdescription tacct)}
           <td .account>
             $forall (Posting { paccount = acc }, (summName,comma)) <- otherTransAccounts torig

--- a/hledger-web/templates/register.hamlet
+++ b/hledger-web/templates/register.hamlet
@@ -5,21 +5,21 @@
   ^{registerChartHtml qparam balancelabel $ accountTransactionsReportByCommodity items}
 
 <div.table-responsive>
-  <table .table.table-striped.table-condensed>
+  <table .table.table-condensed>
     <thead>
       <tr>
-        <th style="text-align:left;">
+        <th>
           Date
           <span .glyphicon.glyphicon-chevron-up>
-        <th style="text-align:left;">Description
-        <th style="text-align:left;">To/From Account(s)
-        <th style="text-align:right; white-space:normal;">Amount Out/In
-        <th style="text-align:right; white-space:normal;">
+        <th>Description
+        <th>To/From Account(s)
+        <th .amount>Amount Out/In
+        <th .amount>
           #{balancelabel}
 
     <tbody>
       $forall (torig, tacct, split, _acct, amt, bal) <- items
-        <tr ##{tindex torig} title="#{showTransaction torig}" style="vertical-align:top;">
+        <tr ##{tindex torig} title="#{showTransaction torig}">
           <td .date nowrap>
             <a href="@?{(JournalR, [("q", T.unwords $ removeInacct qparam)])}##{transactionFrag torig}">
               #{show (tdate tacct)}
@@ -29,10 +29,10 @@
             $forall (Posting { paccount = acc }, (summName,comma)) <- otherTransAccounts torig
               <a href="@?{acctlink acc}##{tindex torig}" title="#{acc}">
                 #{summName}</a>#{comma}
-          <td .amount style="text-align:right; white-space:nowrap;">
+          <td .amount>
             $if not split || not (mixedAmountLooksZero amt)
               ^{mixedAmountAsHtml amt}
-          <td style="text-align:right;">
+          <td .amount>
             ^{mixedAmountAsHtml bal}
 
 $if elem AddPermission perms

--- a/hledger-web/templates/upload-form.hamlet
+++ b/hledger-web/templates/upload-form.hamlet
@@ -5,7 +5,7 @@
   Are you sure? This will overwrite your journal!
 <div.form-group>
   <label .btn.btn-primary for="file">
-    <input type=file id=file name=file style="display:none">
+    <input type=file id=file name=file>
     Select file
   <span .label.label-info id="file-info">
 <div.form-group>


### PR DESCRIPTION
Closes #2705. Follows the direction in #200 and continues from #2702 (javascript scrub).

This is mostly a scrub to simplify our css and move style attributes to the css file.

But, I couldn't resist making three changes that would make the work I do with hledger-web
more serene and focused :).

1. Line up tabular numbers - this should be uncontroversial and is subtle
2. Remove zebra striping - Hover to highlight the row you are inspecting. Improves review ergonomics. Zebra striping does give a nice nostalgic touch, evoking paper, but it works against usability on a screen with richer capabilities.
3. De-emphasize column title - focus should be on the transactions, not the titles.

I'm glad to argue about it. Also glad to revert the opinions and keep the clean up if there's no appetite.

### What changes

- **Alignment moves out of the templates.** 15 `style="text-align:..."` attributes
  across `journal.hamlet` and `register.hamlet` collapse into one rule keyed off
  `.amount`, which `mixedAmountAsHtml` already emits. The register's balance column
  gains the `.amount` class it was missing, so it is styled like every other figure
  column instead of by hand.
- **Amounts get tabular figures.** In the default font a `1` is narrower than an `8`,
  so the digits *inside* a number do not stack even though right alignment already
  lines up the decimal point. Eight amounts of identical digit count render at seven
  different widths, spanning 14.27px; with `font-variant: tabular-nums` all eight are
  68.69px. See image 0.
- **Column headers become small, letter-spaced and muted** instead of bold black,
  with a hairline rule under them. They label the data; they are not part of it.
- **Replace zebra striping with a hover highlight** on the row under the pointer,
  which is what actually helps when reading a wide row across to its amount. Zebra
  stripes are the right answer for paper, but not for a screen where we can do
  better. The `:target` highlight from following a transaction link still wins
  over it.
- **`.date` said `whitespace: nowrap`**, typo prevented rules from applying. see #2717

### Before / after

Image 0 is synthetic to display the effect in an extreme case. The rest are this branch v main.

**0. Amounts — tabular figures**

Look at the alignment of the commas to see what's going on.

<img width="1720" height="1418" alt="0-tabular-figures" src="https://github.com/user-attachments/assets/cd46e614-478e-4658-b1ab-2a8140cea3ca" />

**1. Journal — column headers and tabular figures, in context**

De-emphasize the chrome

<img width="2400" height="1014" alt="1-journal-table" src="https://github.com/user-attachments/assets/19613696-813a-4bfc-82b1-e7329f280438" />

**2. Journal — the row under the pointer**

this could be better

<img width="2400" height="1014" alt="2-journal-hover" src="https://github.com/user-attachments/assets/79569ac4-7c38-43d4-9097-7b3f7150b986" />

**3. Journal — the `:target` highlight after following a link**

No change in appearance: the new hover rule does not override it.

<img width="2400" height="447" alt="3-journal-target" src="https://github.com/user-attachments/assets/42105639-c69f-427f-a147-021ec2c909a3" />

**4. Register — striping removed, balance column now `.amount`**

Hover is the way.....

The image doesn't do it justice. Note that costco is the target here.

<img width="2400" height="1014" alt="4-register-table" src="https://github.com/user-attachments/assets/858a8870-1584-4f04-8c7d-a7998e81d1be" />


**5. Register — rows listing several to/from accounts**

no regression
<img width="2400" height="1146" alt="5-register-valign" src="https://github.com/user-attachments/assets/d96a3c75-2fcd-4b74-a912-546e48b41e8d" />


**6. Journal — narrow window**

no regression

<img width="2400" height="998" alt="6-journal-narrow" src="https://github.com/user-attachments/assets/32babdd8-693e-4c7f-a9e8-e92f22cd037c" />

### Two things in the diff look like they could change behavior but don't

- **`vertical-align:top` comes off the register rows.** Bootstrap already sets
  `.table > tbody > tr > td { vertical-align: top }`, so the inline attribute was
  redundant. Computed `vertical-align` is `top` on both sides.
- **The register amount cell loses `white-space:nowrap`.** This one is a real change
  above 768px — below that, bootstrap's `.table-responsive` reapplies `nowrap`. I could
  not make it produce a visible wrap: a plain amount has no space to break at, and with
  commodities written after the number (`-9876543.21 CHF`), long descriptions and a
  squeezed column at 800/820/900px, cell heights matched the old build to within a
  pixel. Happy to add `white-space: nowrap` to the `.amount` rule if you would rather
  not rely on that.

### STYLE.md

A short document collecting what a change to the appearance has to respect: no build
step, nothing loaded from a third party, style lives in the stylesheet rather than in
`style=` attributes, and how tabular and monetary data is meant to read. Aimed
at coding agents and people.

It also records what is deliberately left alone for now, in rough order of appeal:

- **Bootstrap 3** — the last large vendored asset besides jquery and flot; it also
  brings glyphicons (7 in use, ~148KB of fonts). It's own project
- The responsive grid classes spelled out in `sidebarToggle`.
- The `!important` border rule on posting rows, which fights any row-border work.
- Charts (flot, jquery).
- A strict Content-Security-Policy (#2703), which also decides whether `style-src`
  can be strict.

### Follow-on

Supporting both light and dark color schemes would be nice. Tracked separately in #2706.
