### PR TITLE
web: browse mode without wai-handler-launch

### DIFF
--- a/hledger-web/CHANGES.md
+++ b/hledger-web/CHANGES.md
@@ -111,6 +111,17 @@ Improvements
   reported in the browser's console. The policy also refuses framing
   by another site, as X-Frame-Options does for the other responses.
 
+- The default --serve-browse mode no longer uses the wai-handler-launch
+  library. That library worked by inserting a script into every page,
+  which the new Content-Security-Policy could only allow by hash.
+  hledger-web now does the job itself: it opens the browser, each page
+  pings the server while it is open, and the server exits two minutes
+  after the last ping, so a write-capable server does not linger once
+  its pages are closed. The browser is opened with the open-browser
+  library (the Win32 API on Windows, `open` on mac, `xdg-open`
+  elsewhere), which also fixes hledger's own browser-opening flags,
+  such as --webman, on Windows. (Arthur Cinader)
+
 - The register chart is drawn from data carried on the page rather
   than from a script generated into it. This fixes the chart silently
   disappearing when a commodity symbol contained a backslash and a

--- a/hledger-web/CHANGES.md
+++ b/hledger-web/CHANGES.md
@@ -117,10 +117,10 @@ Improvements
   hledger-web now does the job itself: it opens the browser, each page
   pings the server while it is open, and the server exits two minutes
   after the last ping, so a write-capable server does not linger once
-  its pages are closed. The browser is opened with the open-browser
-  library (the Win32 API on Windows, `open` on mac, `xdg-open`
-  elsewhere), which also fixes hledger's own browser-opening flags,
-  such as --webman, on Windows. (Arthur Cinader)
+  its pages are closed. The browser is opened by hledger's own launcher
+  (the Win32 API on Windows, `open` on mac, `xdg-open` elsewhere), which
+  now also works on Windows for hledger's other browser-opening flags,
+  such as --webman. (Arthur Cinader)
 
 - The register chart is drawn from data carried on the page rather
   than from a script generated into it. This fixes the chart silently

--- a/hledger-web/Hledger/Web/App.hs
+++ b/hledger-web/Hledger/Web/App.hs
@@ -134,7 +134,10 @@ instance Yesod App where
     -- the header and the page's script tags always carry the same nonce;
     -- error pages come through here too, in a handler state of their own.
     nonce <- liftIO newCspNonce
-    addHeader "Content-Security-Policy" $ cspHeader opts nonce
+    addHeader "Content-Security-Policy" $ cspHeader nonce
+    -- In browse mode the page pings the server while it is open (hledger.js);
+    -- the body attribute this sets is how the page knows to.
+    let browsemode = server_mode_ opts == ServeBrowse
 
     let rspec = reportspec_ (cliopts_ opts)
         ropts = _rsReportOpts rspec
@@ -203,26 +206,15 @@ instance RenderMessage App FormMessage where
 -- 'self' assumes the static files come from our own origin. If --file-url
 -- (extraStaticRoot, #2139) is ever re-enabled, that origin has to be added
 -- to default-src as well, or every page will lose its styles and scripts.
---
--- In the default --serve-browse mode, wai-handler-launch's ping middleware
--- inserts its own inline script (its `toInsert`) into every HTML page, so
--- that exact text is also allowed, by hash. If a new wai-handler-launch
--- changes the text, the hash no longer matches, the browser blocks the
--- script, no pings arrive, and the server exits about two minutes after
--- start. The browse-mode browser test in test/browser guards against that.
-cspHeader :: WebOpts -> Text -> Text
-cspHeader opts nonce = T.intercalate "; "
+cspHeader :: Text -> Text
+cspHeader nonce = T.intercalate "; "
   [ "default-src 'self'"
-  , T.unwords $ ["script-src 'self'", "'nonce-" <> nonce <> "'"] ++ launchpinghash
+  , "script-src 'self' 'nonce-" <> nonce <> "'"
   , "object-src 'none'"
   , "base-uri 'self'"
   , "form-action 'self'"
   , "frame-ancestors 'self'"
   ]
-  where
-    launchpinghash
-      | server_mode_ opts == ServeBrowse = ["'sha256-bSudohpsHVaoe+8sUIQa4kptX96txYsZPmJzaESibwo='"]
-      | otherwise = []
 
 -- | A nonce for the policy above: 16 random bytes, base64 encoded.
 newCspNonce :: IO Text

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -24,14 +24,14 @@ If not, see <https://www.gnu.org/licenses/>.
 
 module Hledger.Web.Main where
 
-import Control.Concurrent (forkIO, threadDelay, newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent (forkIO)
 import Control.Concurrent.Async (race)
 import Control.Exception (bracket)
 #if MIN_VERSION_base(4,20,0)
 import Control.Exception.Backtrace (setBacktraceMechanismState, BacktraceMechanism(..))
 #endif
 import Control.Monad (when, void)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Streaming.Network (bindRandomPortTCP)
 import Data.String (fromString)
 import Data.Text qualified as T
@@ -39,11 +39,12 @@ import GHC.Clock (getMonotonicTime)
 import Network.HTTP.Types (status204)
 import Network.Socket
 import Network.Wai (Application, Middleware, pathInfo, responseLBS)
-import Network.Wai.Handler.Warp (runSettings, runSettingsSocket, defaultSettings, setBeforeMainLoop, setHost, setPort)
+import Network.Wai.Handler.Warp (Settings, runSettings, runSettingsSocket, defaultSettings, setBeforeMainLoop, setHost, setPort)
 import System.Directory (removeFile)
 import System.Environment ( getArgs, withArgs )
 import System.IO (hFlush, stdout)
 import System.PosixCompat.Files (getFileStatus, isSocket)
+import System.Time.Extra (sleep)
 import Text.Printf (printf)
 import Yesod.Default.Config
 import Yesod.Default.Main (defaultDevelApp)
@@ -160,19 +161,19 @@ web opts0 j = do
     Nothing -> pure ()
 
   -- start server and maybe browser
+  let warpsettings = setHost (fromString h) (setPort p defaultSettings)
   if server_mode_ opts == ServeBrowse
     then do
       putStrLn "This server will exit after 2m with no browser windows open (or press ctrl-c)"
       putStrLn "Opening web browser..."
       hFlush stdout
       -- returns normally only after the idle exit (ctrl-c or a server failure raises instead)
-      serveAndBrowse h p u app
+      serveAndBrowse warpsettings u app
       putStrLn "No browser windows were open for 2m, exiting. (Use --serve to serve without this timeout.)"
 
     else do
       putStrLn "Press ctrl-c to quit"
       hFlush stdout
-      let warpsettings = setHost (fromString h) (setPort p defaultSettings)
       case (socket_ opts, mtcpsock) of
         (Just s, _) -> do
           if isUnixDomainSocketAvailable then
@@ -203,20 +204,14 @@ web opts0 j = do
 -- minutes. A page says it is open by pinging /_ping while it is (see
 -- browsePingInit in static/hledger.js). The pings are answered here, before
 -- they reach the app, and the time of the latest one is kept.
-serveAndBrowse :: String -> Int -> String -> Application -> IO ()
-serveAndBrowse h p u app = do
-  listening <- newEmptyMVar
-  lastping  <- newIORef =<< getMonotonicTime
-  let warpsettings =
-        setBeforeMainLoop (putMVar listening ()) $
-        setHost (fromString h) $ setPort p defaultSettings
+serveAndBrowse :: Settings -> String -> Application -> IO ()
+serveAndBrowse warpsettings u app = do
+  lastping <- newIORef =<< getMonotonicTime
+  let settings = setBeforeMainLoop (void $ forkIO $ void $ openBrowserOn u) warpsettings
   -- Run these concurrently: when either one finishes or fails, so does the other.
   void $ race
-    (runSettings warpsettings $ answerPings lastping app)
-    (do
-      takeMVar listening
-      _ <- forkIO $ void $ openBrowserOn u
-      waitForIdle lastping)
+    (runSettings settings $ answerPings lastping app)
+    (waitForIdle lastping)
 
 -- | Answer /_ping with 204 No Content, noting the time; pass everything else to the app.
 answerPings :: IORef Double -> Middleware
@@ -233,11 +228,21 @@ waitForIdle lastping = do
   now <- getMonotonicTime
   let remaining = t + browseIdleSeconds - now
   when (remaining > 0) $ do
-    threadDelay $ ceiling $ remaining * 1000000
+    sleep remaining
+    woke <- getMonotonicTime
+    -- On some platforms the clock runs on while the system sleeps, and no
+    -- page could ping meanwhile. If the wait overran by more than a ping
+    -- interval, allow one more interval before deciding.
+    when (woke - now - remaining > browsePingSeconds) $
+      atomicModifyIORef' lastping $ \lp ->
+        (max lp (woke + browsePingSeconds + 5 - browseIdleSeconds), ())
     waitForIdle lastping
 
 -- | How long browse mode keeps serving after the last ping. The pages ping
--- every 30 seconds (hledger.js), so a few pings can go missing before this
--- runs out.
+-- every browsePingSeconds, so a few pings can go missing before this runs out.
 browseIdleSeconds :: Double
 browseIdleSeconds = 120
+
+-- | How often an open page pings, as set in hledger.js.
+browsePingSeconds :: Double
+browsePingSeconds = 30

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -24,18 +24,22 @@ If not, see <https://www.gnu.org/licenses/>.
 
 module Hledger.Web.Main where
 
+import Control.Concurrent (forkIO, threadDelay, newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.Async (race)
 import Control.Exception (bracket)
 #if MIN_VERSION_base(4,20,0)
 import Control.Exception.Backtrace (setBacktraceMechanismState, BacktraceMechanism(..))
 #endif
 import Control.Monad (when, void)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Streaming.Network (bindRandomPortTCP)
 import Data.String (fromString)
 import Data.Text qualified as T
+import GHC.Clock (getMonotonicTime)
+import Network.HTTP.Types (status204)
 import Network.Socket
-import Network.Wai (Application)
-import Network.Wai.Handler.Warp (runSettings, runSettingsSocket, defaultSettings, setHost, setPort)
-import Network.Wai.Handler.Launch (runHostPortFullUrl)
+import Network.Wai (Application, Middleware, pathInfo, responseLBS)
+import Network.Wai.Handler.Warp (runSettings, runSettingsSocket, defaultSettings, setBeforeMainLoop, setHost, setPort)
 import System.Directory (removeFile)
 import System.Environment ( getArgs, withArgs )
 import System.IO (hFlush, stdout)
@@ -161,9 +165,8 @@ web opts0 j = do
       putStrLn "This server will exit after 2m with no browser windows open (or press ctrl-c)"
       putStrLn "Opening web browser..."
       hFlush stdout
-      -- exits after 2m of inactivity (hardcoded);
-      -- returns normally only in that case (ctrl-c or a server failure raises instead)
-      Network.Wai.Handler.Launch.runHostPortFullUrl h p u app
+      -- returns normally only after the idle exit (ctrl-c or a server failure raises instead)
+      serveAndBrowse h p u app
       putStrLn "No browser windows were open for 2m, exiting. (Use --serve to serve without this timeout.)"
 
     else do
@@ -195,3 +198,46 @@ web opts0 j = do
         (Nothing, Just (_, sock)) -> Network.Wai.Handler.Warp.runSettingsSocket warpsettings sock app
         (Nothing, Nothing)        -> Network.Wai.Handler.Warp.runSettings warpsettings app
 
+-- | Browse mode: serve the app, open the default web browser on it once it
+-- is listening, and return when no browser window has shown it for two
+-- minutes. A page says it is open by pinging /_ping while it is (see
+-- browsePingInit in static/hledger.js). The pings are answered here, before
+-- they reach the app, and the time of the latest one is kept.
+serveAndBrowse :: String -> Int -> String -> Application -> IO ()
+serveAndBrowse h p u app = do
+  listening <- newEmptyMVar
+  lastping  <- newIORef =<< getMonotonicTime
+  let warpsettings =
+        setBeforeMainLoop (putMVar listening ()) $
+        setHost (fromString h) $ setPort p defaultSettings
+  -- Run these concurrently: when either one finishes or fails, so does the other.
+  void $ race
+    (runSettings warpsettings $ answerPings lastping app)
+    (do
+      takeMVar listening
+      _ <- forkIO $ void $ openBrowserOn u
+      waitForIdle lastping)
+
+-- | Answer /_ping with 204 No Content, noting the time; pass everything else to the app.
+answerPings :: IORef Double -> Middleware
+answerPings lastping app req send
+  | pathInfo req == ["_ping"] = do
+      writeIORef lastping =<< getMonotonicTime
+      send $ responseLBS status204 [] ""
+  | otherwise = app req send
+
+-- | Return once no ping has arrived for browseIdleSeconds.
+waitForIdle :: IORef Double -> IO ()
+waitForIdle lastping = do
+  t   <- readIORef lastping
+  now <- getMonotonicTime
+  let remaining = t + browseIdleSeconds - now
+  when (remaining > 0) $ do
+    threadDelay $ ceiling $ remaining * 1000000
+    waitForIdle lastping
+
+-- | How long browse mode keeps serving after the last ping. The pages ping
+-- every 30 seconds (hledger.js), so a few pings can go missing before this
+-- runs out.
+browseIdleSeconds :: Double
+browseIdleSeconds = 120

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -203,22 +203,21 @@ hledgerWebTest = do
       return ()
 
     -- No --serve or --serve-api means the default --serve-browse mode, where
-    -- wai-handler-launch inserts its ping script into every page; the policy
-    -- allows that script by its hash. (The library is not in this test
-    -- harness, so only the header can be checked here; the browser suite's
-    -- browse-mode spec checks the script itself.)
-    yit "allows the browse-mode ping script by hash" $ do
+    -- each page pings the server while it is open so that it does not exit.
+    -- The page is told to by a marker on the body. (The pinging and the
+    -- server's answer are outside this harness; the browser suite's
+    -- browse-mode spec checks those.)
+    yit "marks the page for the browse-mode ping" $ do
       get JournalR
-      csp <- cspHeaderValue
-      assertEq "the policy should carry a script hash" (T.isInfixOf "'sha256-" csp) True
+      statusIs 200
+      bodyContains "<body data-browse-mode"
 
   runTests "hledger-web with --serve" [("serve","")] nulljournal $ do
 
-    yit "does not allow the browse-mode ping script, which is not inserted" $ do
+    yit "does not mark the page for the browse-mode ping" $ do
       get JournalR
       statusIs 200
-      csp <- cspHeaderValue
-      assertEq "the policy should carry no script hash" (T.isInfixOf "'sha256-" csp) False
+      bodyNotContains "data-browse-mode"
 
     -- WIP
     -- yit "shows the add form" $ do

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -123,6 +123,7 @@ library
   build-depends:
       Decimal >=0.5.1
     , aeson >=2.2.5.1 && <2.4
+    , async
     , base >=4.18 && <4.23
     , base64-bytestring
     , blaze-html
@@ -164,7 +165,6 @@ library
     , wai-app-static >=3.1
     , wai-cors
     , wai-extra
-    , wai-handler-launch ==3.0.3.1
     , warp
     , yaml
     , yesod >=1.4 && <1.7

--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -53,8 +53,7 @@ hledger-web can be run in three modes:
 - `--serve-browse` mode (the default):
   the app serves the web UI and JSON API,
   and opens your default web browser to show the app if possible,
-  and exits automatically after two minutes of inactivity
-  (with no requests received and no open browser windows viewing it).
+  and exits automatically once no browser window has shown it for two minutes.
 
 - `--serve`: the app just serves the web UI and JSON API.
 

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -106,6 +106,7 @@ library:
   - hledger-lib >=1.99 && <1.100
   - hledger >=1.99 && <1.100
   - aeson >=2.2.5.1 && <2.4  # avoid https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html
+  - async
   - base64-bytestring
   - blaze-html
   - blaze-markup
@@ -143,7 +144,6 @@ library:
   - wai
   - wai-app-static >=3.1
   - wai-extra
-  - wai-handler-launch ==3.0.3.1  # cspHeader in App.hs hashes this version's injected ping script; re-verify before any bump
   - wai-cors
   - warp
   - yaml

--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -5,6 +5,9 @@
 
 document.addEventListener('DOMContentLoaded', function() {
 
+  // First, so that nothing below can stop it.
+  browsePingInit();
+
   // Open and close the dialogs. The data-toggle/data-target/data-dismiss
   // attributes in the templates are the hooks.
   document.querySelectorAll('[data-toggle="modal"]').forEach(function(el) {
@@ -94,7 +97,6 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  browsePingInit();
   registerChartInit();
 });
 
@@ -388,12 +390,15 @@ function registerChartSelect(ev, ranges) {
 // knows a window is open because the page pings it: on load, then every
 // 30 seconds. Pages are marked for this by defaultLayout in browse mode
 // only; the server answers /_ping in that mode only. The ping goes to the
-// page's own origin, whatever address the browser reached us at, not to
-// the base url: the policy allows requests to our origin only.
+// page's own origin, whatever address the browser reached us at (the
+// policy allows requests to our origin only), under the base url's path,
+// in case a proxy in front of us expects one.
 function browsePingInit() {
   if (!document.body.hasAttribute('data-browse-mode')) { return; }
+  var base = new URL(document.hledgerWebBaseurl, document.baseURI);
+  var url = base.pathname.replace(/\/$/, '') + '/_ping';
   var ping = function() {
-    fetch('/_ping', { cache: 'no-store' }).catch(function() {});
+    fetch(url, { cache: 'no-store' }).catch(function() {});
   };
   ping();
   setInterval(ping, 30000);

--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -94,6 +94,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
+  browsePingInit();
   registerChartInit();
 });
 
@@ -377,4 +378,23 @@ function registerChartSelect(ev, ranges) {
   var q = url.searchParams.get('q');
   url.searchParams.set('q', (q ? q + ' ' : '') + 'date:' + range);
   document.location = url.href;
+}
+
+//----------------------------------------------------------------------
+// BROWSE MODE
+
+// In the default --serve-browse mode the server exits once no browser
+// window has shown it for two minutes (serveAndBrowse in Main.hs). It
+// knows a window is open because the page pings it: on load, then every
+// 30 seconds. Pages are marked for this by defaultLayout in browse mode
+// only; the server answers /_ping in that mode only. The ping goes to the
+// page's own origin, whatever address the browser reached us at, not to
+// the base url: the policy allows requests to our origin only.
+function browsePingInit() {
+  if (!document.body.hasAttribute('data-browse-mode')) { return; }
+  var ping = function() {
+    fetch('/_ping', { cache: 'no-store' }).catch(function() {});
+  };
+  ping();
+  setInterval(ping, 30000);
 }

--- a/hledger-web/templates/default-layout-wrapper.hamlet
+++ b/hledger-web/templates/default-layout-wrapper.hamlet
@@ -16,7 +16,7 @@ $newline never
           document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/,'js');
           document.hledgerWebBaseurl = '#{base_url_ opts}'; // save for binding keys later
 
-    <body>
+    <body :browsemode:data-browse-mode>
         <div .container-fluid>
             <div .row .row-offcanvas .row-offcanvas-left>
               ^{pageBody pc}

--- a/hledger-web/test/browser/README.md
+++ b/hledger-web/test/browser/README.md
@@ -13,9 +13,9 @@ highlighting.
   sent, nothing on any page violates it, and a script without the nonce is blocked.
 - `helpers.js`, `server.js` — shared by the specs: collecting policy violations and page
   errors, and starting hledger-web.
-- `browse-mode.spec.js` — the default mode (no `--serve`), where the browser launcher
-  inserts a ping script into every page: the policy allows it. This spec starts a
-  second hledger-web on port 5089 (`HLEDGER_WEB_BROWSE_PORT`) with the launcher
+- `browse-mode.spec.js` — the default mode (no `--serve`), where each page pings
+  the server while it is open so that it keeps serving. This spec starts a second
+  hledger-web on port 5089 (`HLEDGER_WEB_BROWSE_PORT`) with the browser launcher
   stubbed; it is skipped on Windows, where the launch cannot be intercepted.
 
 Nothing here is part of `stack build` or `stack test`; the suite is opt-in and needs

--- a/hledger-web/test/browser/browse-mode.spec.js
+++ b/hledger-web/test/browser/browse-mode.spec.js
@@ -1,15 +1,14 @@
-// The default mode, with no --serve flag, runs hledger-web through
-// wai-handler-launch: it opens a browser, inserts a ping script into every
-// page, and exits the server when the pings stop. The Content-Security-Policy
-// allows that script by its hash (cspHeader in App.hs). If a new version of
-// the library changed the script's text, the hash would no longer match, the
-// browser would block the script, and hledger-web would exit about two
-// minutes into every session. This spec is the only automated check of that.
+// The default mode, with no --serve flag, opens a browser on hledger-web and
+// exits the server once no browser window has shown it for two minutes. The
+// page tells the server it is open by pinging /_ping, from hledger.js, on
+// load and then periodically (serveAndBrowse in Main.hs). This spec checks
+// that the page is marked for the ping in this mode, that the ping goes out
+// and is answered, and that it does so without any policy violation.
 //
 // It starts its own hledger-web, on port 5089 (HLEDGER_WEB_BROWSE_PORT), with
-// the browser launcher stubbed out: the library runs `open` on macOS and
-// `xdg-open` elsewhere, found on PATH. On Windows it calls ShellExecute
-// directly, which cannot be intercepted, so the spec is skipped there.
+// the browser launcher stubbed out: hledger opens the browser with `open` on
+// macOS and `xdg-open` elsewhere, found on PATH. On Windows it runs rundll32,
+// which cannot be stubbed that way, so the spec is skipped there.
 const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const os = require('os');
@@ -44,19 +43,15 @@ test.afterAll(() => {
   try { fs.rmSync(tmpdir, { recursive: true, force: true }); } catch (e) { /* fine */ }
 });
 
-test('in browse mode, the launcher\'s ping script is allowed by the policy and runs', async ({ page }) => {
+test('in browse mode, the page pings the server so that it keeps serving', async ({ page }) => {
   const violations = await watchViolations(page);
   const pageErrors = watchPageErrors(page);
+  const ping = page.waitForRequest(req => req.url().startsWith(URL + '/_ping'));
 
   const response = await page.goto(URL + '/journal');
-  expect(response.headers()['content-security-policy'])
-    .toMatch(/script-src 'self' 'nonce-[^']+' 'sha256-[A-Za-z0-9+/]{43}='/);
-  // the library's script is in the page, without a nonce, and was not blocked
-  const pingScripts = await page.evaluate(() =>
-    Array.from(document.scripts).filter(s => !s.src && s.textContent.includes('/_ping')).length);
-  expect(pingScripts).toBe(1);
+  expect(response.headers()['content-security-policy']).not.toContain('sha256-');
+  await expect(page.locator('body')).toHaveAttribute('data-browse-mode');
+  expect((await (await ping).response()).status()).toBe(204);
   await expectNoViolations(page, violations);
   expect(pageErrors).toEqual([]);
-  // and the endpoint it pings is in place
-  expect((await page.request.get(URL + '/_ping?' + Date.now())).status()).toBe(200);
 });

--- a/hledger/CHANGES.md
+++ b/hledger/CHANGES.md
@@ -104,6 +104,12 @@ User-visible changes in the hledger command line tool and library.
 
 - `help` now has `h` as its official alias.
 
+- Opening a web page in the browser (`help home`, `--webman` and friends)
+  now works on Windows, where it tried a fixed Firefox path. It now goes
+  through the open-browser library, which uses the Win32 API there,
+  `open` on mac and `xdg-open` on Linux and the BSDs; the older Linux
+  launchers remain as fallbacks. (Arthur Cinader)
+
 - The commands list can now be limited to particular categories of
   command with `help commands --builtins`, `--addons` or `--aliases`;
   the flags can be combined. (`--builtin` has been renamed to

--- a/hledger/CHANGES.md
+++ b/hledger/CHANGES.md
@@ -105,10 +105,10 @@ User-visible changes in the hledger command line tool and library.
 - `help` now has `h` as its official alias.
 
 - Opening a web page in the browser (`help home`, `--webman` and friends)
-  now works on Windows, where it tried a fixed Firefox path. It now goes
-  through the open-browser library, which uses the Win32 API there,
-  `open` on mac and `xdg-open` on Linux and the BSDs; the older Linux
-  launchers remain as fallbacks. (Arthur Cinader)
+  now works on Windows, where it tried a fixed Firefox path; it now asks
+  the Win32 API, through the open-browser library. On Linux, `xdg-open`
+  is tried first, and a launcher that is not installed no longer stops
+  the others from being tried. (Arthur Cinader)
 
 - The commands list can now be limited to particular categories of
   command with `help commands --builtins`, `--addons` or `--aliases`;

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -282,14 +282,17 @@ maybeFileModificationTime f = do
     return Nothing
 
 -- | Attempt to open a web browser on the given url, all platforms.
--- First through the open-browser package, which uses the Win32 API on
--- Windows, `open` on mac and `xdg-open` on Linux and the BSDs; then, on
--- Linux, through some other launchers that may be installed (one that is
--- not counts as failing). If nothing starts, print the url instead.
+-- On Windows this goes through the open-browser package, which asks the
+-- Win32 API to open the url. Elsewhere it runs the platform's launchers in
+-- turn until one exits successfully (one that is not installed counts as
+-- failing): `open` on mac; `xdg-open` and then some older launchers that
+-- may be installed on Linux. If nothing starts, print the url instead.
 openBrowserOn :: String -> IO ExitCode
-openBrowserOn u = do
-  ok <- openBrowser u
-  if ok then return ExitSuccess else trylaunchers launchers
+openBrowserOn u
+  | os == "mingw32" = do
+      ok <- openBrowser u
+      if ok then return ExitSuccess else couldnotstart ["the Win32 API"]
+  | otherwise = trylaunchers launchers
     where
       trylaunchers (cmd:rest) = do
         r <- try $ readProcessWithExitCode cmd [u] ""
@@ -297,15 +300,13 @@ openBrowserOn u = do
           Right (ExitSuccess,_,_)    -> return ExitSuccess
           Right (ExitFailure _,_,_)  -> trylaunchers rest
           Left (_ :: IOException)    -> trylaunchers rest
-      trylaunchers [] = do
-        putStrLn $ printf "Could not start a web browser (tried: %s)" $ intercalate ", " $ launcher0 : launchers
+      trylaunchers [] = couldnotstart launchers
+      couldnotstart tried = do
+        putStrLn $ printf "Could not start a web browser (tried: %s)" $ intercalate ", " tried
         putStrLn $ printf "Please open your browser and visit %s" u
         return $ ExitFailure 127
-      launcher0 | os == "darwin"  = "open"
-                | os == "mingw32" = "ShellExecute"
-                | otherwise       = "xdg-open"
-      launchers | os `elem` ["darwin", "mingw32"] = []
-                | otherwise = ["sensible-browser", "gnome-www-browser", "firefox"]
+      launchers | os == "darwin" = ["open"]
+                | otherwise      = ["xdg-open", "sensible-browser", "gnome-www-browser", "firefox"]
 
 -- | Back up this file with a (incrementing) numbered suffix then
 -- overwrite it with this new text, or give an error, but only if the text

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -31,6 +31,7 @@ module Hledger.Cli.Utils
     )
 where
 
+import Control.Exception (IOException, try)
 import Control.Monad.Except (ExceptT)
 import Control.Monad.IO.Class (liftIO)
 import Data.List
@@ -54,6 +55,7 @@ import System.Info (os)
 import System.Process (readProcessWithExitCode)
 import Text.Printf
 import Text.Regex.TDFA ((=~))
+import Web.Browser (openBrowser)
 
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Anon
@@ -280,26 +282,30 @@ maybeFileModificationTime f = do
     return Nothing
 
 -- | Attempt to open a web browser on the given url, all platforms.
+-- First through the open-browser package, which uses the Win32 API on
+-- Windows, `open` on mac and `xdg-open` on Linux and the BSDs; then, on
+-- Linux, through some other launchers that may be installed (one that is
+-- not counts as failing). If nothing starts, print the url instead.
 openBrowserOn :: String -> IO ExitCode
-openBrowserOn = trybrowsers browsers
+openBrowserOn u = do
+  ok <- openBrowser u
+  if ok then return ExitSuccess else trylaunchers launchers
     where
-      trybrowsers (b:bs) u1 = do
-        (e,_,_) <- readProcessWithExitCode b [u1] ""
-        case e of
-          ExitSuccess -> return ExitSuccess
-          ExitFailure _ -> trybrowsers bs u1
-      trybrowsers [] u1 = do
-        putStrLn $ printf "Could not start a web browser (tried: %s)" $ intercalate ", " browsers
-        putStrLn $ printf "Please open your browser and visit %s" u1
+      trylaunchers (cmd:rest) = do
+        r <- try $ readProcessWithExitCode cmd [u] ""
+        case r of
+          Right (ExitSuccess,_,_)    -> return ExitSuccess
+          Right (ExitFailure _,_,_)  -> trylaunchers rest
+          Left (_ :: IOException)    -> trylaunchers rest
+      trylaunchers [] = do
+        putStrLn $ printf "Could not start a web browser (tried: %s)" $ intercalate ", " $ launcher0 : launchers
+        putStrLn $ printf "Please open your browser and visit %s" u
         return $ ExitFailure 127
-      browsers | os=="darwin"  = ["open"]
-               | os=="mingw32" = ["c:/Program Files/Mozilla Firefox/firefox.exe"]
-               | otherwise     = ["sensible-browser","gnome-www-browser","firefox"]
-    -- jeffz: write a ffi binding for it using the Win32 package as a basis
-    -- start by adding System/Win32/Shell.hsc and follow the style of any
-    -- other module in that directory for types, headers, error handling and
-    -- what not.
-    -- ::ShellExecute(NULL, "open", "www.somepage.com", NULL, NULL, SW_SHOWNORMAL);
+      launcher0 | os == "darwin"  = "open"
+                | os == "mingw32" = "ShellExecute"
+                | otherwise       = "xdg-open"
+      launchers | os `elem` ["darwin", "mingw32"] = []
+                | otherwise = ["sensible-browser", "gnome-www-browser", "firefox"]
 
 -- | Back up this file with a (incrementing) numbered suffix then
 -- overwrite it with this new text, or give an error, but only if the text

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -176,6 +176,7 @@ library
     , microlens >=0.4
     , modern-uri >=0.3
     , mtl >=2.2.1
+    , open-browser >=0.5
     , pretty
     , process
     , regex-tdfa
@@ -231,6 +232,7 @@ executable hledger
     , megaparsec >=7.0.0 && <9.8 || >=9.8.0 && <9.9
     , microlens >=0.4
     , mtl >=2.2.1
+    , open-browser >=0.5
     , process
     , regex-tdfa
     , req
@@ -282,6 +284,7 @@ test-suite unittest
     , megaparsec >=7.0.0 && <9.8 || >=9.8.0 && <9.9
     , microlens >=0.4
     , mtl >=2.2.1
+    , open-browser >=0.5
     , process
     , regex-tdfa
     , req
@@ -335,6 +338,7 @@ benchmark bench
     , megaparsec >=7.0.0 && <9.8 || >=9.8.0 && <9.9
     , microlens >=0.4
     , mtl >=2.2.1
+    , open-browser >=0.5
     , process
     , regex-tdfa
     , req

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -122,6 +122,7 @@ dependencies:
 - microlens >=0.4
 - megaparsec >=7.0.0 && <9.8 || >=9.8.0 && <9.9
 - mtl >=2.2.1
+- open-browser >=0.5
 - process
 - regex-tdfa
 - req

--- a/stack910.yaml
+++ b/stack910.yaml
@@ -10,6 +10,10 @@ packages:
 - hledger-ui
 - hledger-web
 
+extra-deps:
+# for hledger's openBrowserOn (Windows launch through the Win32 API)
+- open-browser-0.5.1.0
+
 nix:
   pure: false
   packages: [perl gmp ncurses zlib]

--- a/stack96.yaml
+++ b/stack96.yaml
@@ -21,6 +21,8 @@ extra-deps:
 - text-iso8601-0.1.1.2
 - character-ps-0.1
 - hashable-1.4.6.0
+# for hledger's openBrowserOn (Windows launch through the Win32 API)
+- open-browser-0.5.1.0
 - attoparsec-aeson-2.2.2.0
 
 nix:

--- a/stack98.yaml
+++ b/stack98.yaml
@@ -18,6 +18,8 @@ extra-deps:
 # for hledger-web and https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html
 - aeson-2.2.5.1
 - text-iso8601-0.1.1.2
+# for hledger's openBrowserOn (Windows launch through the Win32 API)
+- open-browser-0.5.1.0
 
 nix:
   pure: false


### PR DESCRIPTION
The follow-up to #2720: hledger-web's default `--serve-browse` mode no longer uses wai-handler-launch.

**Why.** The library inserted an inline ping script into every HTML page, which the Content-Security-Policy could only allow by hash, with the package pinned to one exact version to keep the hash honest. Its browser launch on Windows also went through a C shim.

**What replaces it.** About 45 lines in `Main.hs`, keeping the library's process shape (warp with a before-main-loop hook, browser opened once listening, `race` between warp and an idle wait, so a warp failure still raises and only the idle exit returns normally):

- a WAI middleware answers `/_ping` with 204 and stamps a monotonic clock, before the request reaches the app, as the library did;
- the idle wait exits exactly 120s after the last ping (the library exited anywhere from 2 to 4 minutes after it), so the "no browser windows were open for 2m" message is now literally true;
- the ping moves to `hledger.js`: on load, then every 30s (the library pinged every 60s against the same limit, so one missed ping could end a session). It runs only when `defaultLayout` has marked the body with `data-browse-mode`, which it does in browse mode only, so `--serve` pages never ping. It goes to the page's own origin, not the base url, since the policy allows requests to our origin only;
- `openBrowserOn` in hledger now tries the open-browser package first (ShellExecuteW via the Win32 API on Windows, `open` on mac, `xdg-open` on Linux and the BSDs), then the old Linux fallbacks, skipping ones that are not installed. This fixes the Windows branch, which ran a fixed Firefox path, for `--webman` and the `help` pages too.

The hash and the version pin leave the policy and `package.yaml`; wai-handler-launch is replaced by open-browser (in hledger) and async (in hledger-web).

**Tests.** The yesod tests check the body marker in browse mode and its absence with `--serve`. The browser suite's browse-mode spec waits for the actual ping request and checks its 204, with the launcher stubbed on PATH. A timed run with the stub exited 120s after the last ping to the second. The Windows launch cannot be exercised here: the browser suite does not run on Windows, and CI's Windows job builds and unit-tests only.

**Follow-up.** `--port 0` is still refused in browse mode. That restriction (from #2559) existed only because the library needed a known port up front; with warp run by hledger-web itself it can be lifted, and I'll do that in a separate PR.


AI usage: Claude Fable 5.1 throughout, ~60k output tokens (including a code review pass); both commit messages and this description were reviewed and edited by me before publishing.
