### PR TITLE
web: --port 0 now works in --serve-browse mode too

### DIFF
--- a/hledger-web/CHANGES.md
+++ b/hledger-web/CHANGES.md
@@ -61,8 +61,8 @@ Improvements
 
 - --port 0 lets the OS choose a free port [#2559] (Arthur Cinader).
   The chosen port is reported in the startup message and used in the
-  default base url, so scripts can discover it. Supported with --serve
-  and --serve-api.
+  default base url, so scripts can discover it; in the default
+  --serve-browse mode, the browser is opened there.
 
 - Add the -? and --webman flags; rename --tldr to --examples (see hledger changelog).
 

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -119,13 +119,8 @@ web opts0 j = do
       staticRoot = T.pack <$> file_url_ opts  -- XXX not used #2139
 
   -- --port 0 means "let the operating system choose a free port". To learn which
-  -- port it chose (so we can report it and build the base url), we must bind the
-  -- listening socket ourselves rather than let warp do it. This isn't supported in
-  -- --serve-browse mode, which needs a known port up front to open the browser at.
-  when (p0 == 0 && socket_ opts == Nothing && server_mode_ opts == ServeBrowse) $
-    error' $ unlines  -- PARTIAL:
-      ["--port 0 (let the operating system choose a free port) is not supported with --serve-browse."
-      ,"Please use --serve or --serve-api instead, which will report the chosen port."]
+  -- port it chose (so we can report it, build the base url, and open the browser
+  -- there), we must bind the listening socket ourselves rather than let warp do it.
   mtcpsock <- if p0 == 0 && socket_ opts == Nothing
                 then Just <$> bindRandomPortTCP (fromString h)
                 else return Nothing
@@ -168,7 +163,7 @@ web opts0 j = do
       putStrLn "Opening web browser..."
       hFlush stdout
       -- returns normally only after the idle exit (ctrl-c or a server failure raises instead)
-      serveAndBrowse warpsettings u app
+      serveAndBrowse warpsettings (snd <$> mtcpsock) u app
       putStrLn "No browser windows were open for 2m, exiting. (Use --serve to serve without this timeout.)"
 
     else do
@@ -204,13 +199,16 @@ web opts0 j = do
 -- minutes. A page says it is open by pinging /_ping while it is (see
 -- browsePingInit in static/hledger.js). The pings are answered here, before
 -- they reach the app, and the time of the latest one is kept.
-serveAndBrowse :: Settings -> String -> Application -> IO ()
-serveAndBrowse warpsettings u app = do
+-- With --port 0 the listening socket is already bound (to the port the OS
+-- chose, which is the one in the url); serve on it rather than on host and port.
+serveAndBrowse :: Settings -> Maybe Socket -> String -> Application -> IO ()
+serveAndBrowse warpsettings msock u app = do
   lastping <- newIORef =<< getMonotonicTime
   let settings = setBeforeMainLoop (void $ forkIO $ void $ openBrowserOn u) warpsettings
+      serve = maybe (runSettings settings) (runSettingsSocket settings) msock
   -- Run these concurrently: when either one finishes or fails, so does the other.
   void $ race
-    (runSettings settings $ answerPings lastping app)
+    (serve $ answerPings lastping app)
     (waitForIdle lastping)
 
 -- | Answer /_ping with 204 No Content, noting the time; pass everything else to the app.

--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -98,9 +98,8 @@ The special address `0.0.0.0` causes it to listen on all of this machine's addre
 Similarly, you can use `--port` to listen on a TCP port other than 5000.
 This is useful if you want to run multiple hledger-web instances on a machine.
 `--port 0` makes the operating system choose a free port, which is reported
-in the startup message and in the default base url. This can be useful eg
-when scripting; it is supported with `--serve` and `--serve-api`, but not
-with `--serve-browse`.
+in the startup message and in the default base url, and is where the browser
+is opened in `--serve-browse` mode. This can be useful eg when scripting.
 
 When `--socket` is used, hledger-web creates and communicates via a socket file instead of a TCP port.
 This can be more secure, respects unix file permissions, and makes certain use cases easier,

--- a/hledger-web/test/browser/README.md
+++ b/hledger-web/test/browser/README.md
@@ -15,8 +15,9 @@ highlighting.
   errors, and starting hledger-web.
 - `browse-mode.spec.js` — the default mode (no `--serve`), where each page pings
   the server while it is open so that it keeps serving. This spec starts a second
-  hledger-web on port 5089 (`HLEDGER_WEB_BROWSE_PORT`) with the browser launcher
-  stubbed; it is skipped on Windows, where the launch cannot be intercepted.
+  hledger-web, with `--port 0` and the browser launcher stubbed, and checks that
+  the browser is opened at the port the OS chose; it is skipped on Windows, where
+  the launch cannot be intercepted.
 
 Nothing here is part of `stack build` or `stack test`; the suite is opt-in and needs
 node only to run it.

--- a/hledger-web/test/browser/browse-mode.spec.js
+++ b/hledger-web/test/browser/browse-mode.spec.js
@@ -3,12 +3,15 @@
 // page tells the server it is open by pinging /_ping, from hledger.js, on
 // load and then periodically (serveAndBrowse in Main.hs). This spec checks
 // that the page is marked for the ping in this mode, that the ping goes out
-// and is answered, and that it does so without any policy violation.
+// and is answered, and that it does so without any policy violation. It also
+// checks that with --port 0 the browser is opened at the port the OS chose.
 //
-// It starts its own hledger-web, on port 5089 (HLEDGER_WEB_BROWSE_PORT), with
-// the browser launcher stubbed out: hledger opens the browser with `open` on
-// macOS and `xdg-open` elsewhere, found on PATH. On Windows it runs rundll32,
-// which cannot be stubbed that way, so the spec is skipped there.
+// It starts its own hledger-web with --port 0, learning the url from the
+// startup banner, and with the browser launcher stubbed out: hledger opens
+// the browser with `open` on macOS and `xdg-open` elsewhere, found on PATH,
+// and the stub records the url it was given. On Windows the browser is
+// opened through the Win32 API, which cannot be stubbed that way, so the spec
+// is skipped there.
 const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const os = require('os');
@@ -16,26 +19,25 @@ const path = require('path');
 const { startServer } = require('./server');
 const { watchViolations, watchPageErrors, expectNoViolations } = require('./helpers');
 
-const PORT = process.env.HLEDGER_WEB_BROWSE_PORT || '5089';
-const URL = `http://127.0.0.1:${PORT}`;
-
 test.skip(process.platform === 'win32', 'the browser launch cannot be stubbed on Windows');
 
-let server, tmpdir;
+let server, URL, tmpdir, launched;
 
 test.beforeAll(async () => {
   // starting the server can take longer than the 30s hook timeout, eg on a cold stack
   test.setTimeout(120000);
   tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hledger-web-browse-'));
+  // the launcher stubs record the url they are asked to open
+  launched = path.join(tmpdir, 'launched.txt');
   for (const name of ['open', 'xdg-open']) {
     const stub = path.join(tmpdir, name);
-    fs.writeFileSync(stub, '#!/bin/sh\nexit 0\n');
+    fs.writeFileSync(stub, `#!/bin/sh\necho "$1" >> '${launched}'\nexit 0\n`);
     fs.chmodSync(stub, 0o755);
   }
   const journal = path.join(tmpdir, 'browse.journal');
   fs.copyFileSync(path.join(__dirname, 'fixture.journal'), journal);
-  server = await startServer(URL, ['-f', journal, '--host', '127.0.0.1', '--port', PORT],
-    { PATH: tmpdir + path.delimiter + process.env.PATH });
+  ({ child: server, url: URL } = await startServer(['-f', journal, '--host', '127.0.0.1', '--port', '0'],
+    { PATH: tmpdir + path.delimiter + process.env.PATH }));
 });
 
 test.afterAll(() => {
@@ -54,4 +56,11 @@ test('in browse mode, the page pings the server so that it keeps serving', async
   expect((await (await ping).response()).status()).toBe(204);
   await expectNoViolations(page, violations);
   expect(pageErrors).toEqual([]);
+});
+
+test('with --port 0, the browser is opened at the port the OS chose', async () => {
+  expect(URL).not.toMatch(/:0$/);
+  // the launcher runs in the background once the server is listening
+  await expect.poll(() => fs.existsSync(launched) ? fs.readFileSync(launched, 'utf8').trim() : '')
+    .toBe(URL);
 });

--- a/hledger-web/test/browser/global-setup.js
+++ b/hledger-web/test/browser/global-setup.js
@@ -14,7 +14,7 @@ module.exports = async () => {
   fs.copyFileSync(path.join(__dirname, 'fixture.journal'), journal);
   process.env.BROWSER_JOURNAL = journal;
 
-  const child = await startServer(URL, [
+  const { child } = await startServer([
     '-f', journal, '--serve', '--host', '127.0.0.1', '--port', PORT, '--allow=edit',
   ]);
   fs.writeFileSync(path.join(os.tmpdir(), 'hledger-web-browser.pid'), String(child.pid));

--- a/hledger-web/test/browser/server.js
+++ b/hledger-web/test/browser/server.js
@@ -34,20 +34,40 @@ function waitForServer(url, timeoutMs) {
 }
 
 // Start hledger-web with the given arguments, detached, and resolve with the
-// child process once it answers at url. `env` adds to or overrides the
-// environment it runs in.
-async function startServer(url, args, env) {
+// child process and the base url from its startup banner, once it answers
+// there. With --port 0 that url carries the port the OS chose. `env` adds to
+// or overrides the environment it runs in.
+async function startServer(args, env) {
   const [cmd, ...cmdargs] = serverCommand();
   const child = spawn(cmd, [...cmdargs, ...args],
-    { stdio: 'ignore', detached: true, env: { ...process.env, ...(env || {}) } });
+    { stdio: ['ignore', 'pipe', 'pipe'], detached: true, env: { ...process.env, ...(env || {}) } });
   child.unref();
+  const url = await new Promise((resolve, reject) => {
+    let out = '';
+    const done = (fn) => (arg) => {
+      clearTimeout(timer);
+      child.stdout.off('data', onData); child.stderr.off('data', onData); child.off('exit', onExit);
+      fn(arg);
+    };
+    const succeed = done(resolve), fail = done(reject);
+    const timer = setTimeout(() => fail(new Error('hledger-web did not report its base url:\n' + out)), 60000);
+    const onData = chunk => {
+      out += chunk;
+      const m = out.match(/^with base url (\S+)\n/m);
+      if (m) succeed(m[1]);
+    };
+    const onExit = code => fail(new Error(`hledger-web exited with ${code}:\n` + out));
+    child.stdout.on('data', onData); child.stderr.on('data', onData); child.on('exit', onExit);
+  });
+  // keep draining its output, or it would block once the pipes fill up
+  child.stdout.resume(); child.stderr.resume();
   try {
     await waitForServer(url, 60000);
   } catch (e) {
     try { process.kill(child.pid); } catch (_) { /* already gone */ }
     throw e;
   }
-  return child;
+  return { child, url };
 }
 
 module.exports = { startServer };


### PR DESCRIPTION
`--port 0` (#2559, let the OS choose a free port) now works in the default `--serve-browse` mode as well.

Follows #2722, now merged. 

Prior to #2722 we errored when trying to get the OS to assign a port in `--serve-browse` mode, because the browser launcher of the time, wai-handler-launch, had to be given a port number up front. Since #2722, hledger-web runs warp itself in that mode, so it can serve on the socket it already bound to the OS-chosen port, exactly as `--serve` does, and open the browser at the base url built from that port. This removes the exception and its error message, and the manual's and changelog's caveats about it.

The browse-mode browser spec now starts its server with `--port 0` rather than on a fixed port, and its launcher stub records the url it is asked to open, so the spec also checks that the browser is opened at the chosen port. To support that, the suite's one server starter now reads the url from the startup banner, for both of its callers, and keeps the server's output so that a failure to start is reported with its message.

AI usage: Claude Fable 5.1, ~8k output tokens; the commit message and this description were reviewed and edited by me before publishing.

